### PR TITLE
Rest api update

### DIFF
--- a/custom-post-types.php
+++ b/custom-post-types.php
@@ -24,6 +24,7 @@ abstract class CustomPostType{
 		$taxonomies     = array('post_tag'),
 		$built_in       = False,
 		$rewrite 		= True,
+		$show_in_rest   = False,
 
 		# Optional default ordering for generic shortcode if not specified by user.
 		$default_orderby = null,
@@ -171,14 +172,20 @@ abstract class CustomPostType{
 	 **/
 	public function register(){
 		$registration = array(
-			'labels'     => $this->labels(),
-			'supports'   => $this->supports(),
-			'public'     => $this->options('public'),
-			'taxonomies' => $this->options('taxonomies'),
-			'_builtin'   => $this->options('built_in'),
-			'rewrite'	 => $this->options('rewrite'),
+			'labels'       => $this->labels(),
+			'supports'     => $this->supports(),
+			'public'       => $this->options('public'),
+			'taxonomies'   => $this->options('taxonomies'),
+			'_builtin'     => $this->options('built_in'),
+			'rewrite'	   => $this->options('rewrite')
 		);
-		
+
+		if ( $this->options('show_in_rest') ) {
+			$registration['show_in_rest'] = True;
+			$registration['rest_base'] = $this->name . 's';
+			$registration['rest_controller_class'] = 'WP_REST_Posts_Controller';
+		}
+
 		if ($this->options('use_order')){
 			$registration = array_merge($registration, array('hierarchical' => True,));
 		}
@@ -328,7 +335,8 @@ class Post extends CustomPostType
 		$use_title = True,
 		$use_metabox = True,
 		$taxonomies = array('experts', 'post_tag', 'category'),
-		$built_in = True;
+		$built_in = True,
+		$show_in_rest = True;
 		
 	public function fields() {
 		global $post;

--- a/functions.php
+++ b/functions.php
@@ -911,4 +911,36 @@ function add_image_to_post_feed(  ) {
 
 add_action( 'rest_api_init', 'add_image_to_post_feed' );
 
+function add_tax_query_to_posts_endpoint( $args, $request ) {
+	$params = $request->get_params();
+
+	$tax_query = array();
+	
+	if ( isset( $params['category_slugs'] ) ) {
+		$tax_query[] =
+			array(
+				'taxonomy' => 'category',
+				'field'    => 'slug',
+				'terms'    => $params['category_slugs']
+			);
+	}
+
+	if ( isset( $params['tag_slugs'] ) ) {
+		$tax_query[] =
+			array(
+				'taxonomy' => 'post_tag',
+				'field'    => 'slug',
+				'terms'    => $params['tag_slugs']
+			);
+	}
+
+	if ( count( $tax_query ) > 0 ) {
+		$args['tax_query'] = $tax_query;
+	}
+
+	return $args;
+}
+
+add_action( 'rest_post_query', 'add_tax_query_to_posts_endpoint', 2, 10 );
+
 ?>


### PR DESCRIPTION
Added an option to add a rest_api endpoint for our custom post types. By default, it will use the WP_REST_Posts_Controller to create the endpoint.

Verified that with the WP REST API plugin still installed and v4.7.2 installed, everything still works properly. Verified with WP REST API plugin deactivated/uninstalled and v4.7.2 installed, everything works as intended.