### PR TITLE
Featured story video fix

### DIFF
--- a/shortcodes.php
+++ b/shortcodes.php
@@ -232,12 +232,12 @@ function sc_feature($atts = Array(), $id_only = False)
 
 			if($video_url != '') :
 			?>
-			<div class="video-container" style="background-image: url('.$attachment_url[0].');">'
+			<div class="video-container" style="background-image: url('<?=$attachment_url[0]?>');">'
 				<?=$wp_embed->run_shortcode('[embed width="417" height="343"]'.$video_url.'[/embed]')?>
 			</div>
 			<? else :
 			?>
-			<div class="thumb cropped" style="background-image: url('.$attachment_url[0].');">
+			<div class="thumb cropped" style="background-image: url('<?=$attachment_url[0]?>');">
 				<a href="'.get_permalink($feature->ID).'">
 					<?=get_img_html($feature->ID, 'feature')?>
 				</a>
@@ -279,7 +279,7 @@ function sc_feature($atts = Array(), $id_only = False)
 
 		if($video_url != '') :
 		?>
-		<div class="video-container" style="background-image: url('.$attachment_url[0].');">'
+		<div class="video-container" style="background-image: url('<?=$attachment_url[0]?>');">'
 			<?=$wp_embed->run_shortcode('[embed width="417" height="343"]'.$video_url.'[/embed]')?>
 		</div>
 		<?

--- a/shortcodes.php
+++ b/shortcodes.php
@@ -222,25 +222,24 @@ function sc_feature($atts = Array(), $id_only = False)
 
 		if($feature !== False) {
 			$video_url = get_video_url($feature->ID);
+			$feature_media_attachment = get_img_html($feature->ID, 'feature', array('return_id' => true));
+			$attachment_url = wp_get_attachment_image_src($feature_media_attachment['attachment_id'], 'feature');
+			if (!$attachment_url) {
+				$attachment_url = array(0 => THEME_IMG_URL.'/no-photo.png');
+			}
 
 			if($video_url != '') {
-				$feature_media = $wp_embed->run_shortcode('[embed width="417" height="343"]'.$video_url.'[/embed]');
+				$feature_media = '<div class="video-container" style="background-image: url('.$attachment_url[0].');">'.$wp_embed->run_shortcode('[embed width="417" height="343"]'.$video_url.'[/embed]</div>');
 			} else {
-				$feature_media = '<a href="'.get_permalink($feature->ID).'">'.get_img_html($feature->ID, 'feature').'</a>';
-				$feature_media_attachment = get_img_html($feature->ID, 'feature', array('return_id' => true));
-				$attachment_url = wp_get_attachment_image_src($feature_media_attachment['attachment_id'], 'feature');
-				if (!$attachment_url) {
-					$attachment_url = array(0 => THEME_IMG_URL.'/no-photo.png');
-				}
+				$feature_media = '<div class="thumb cropped" style="background-image: url('.$attachment_url[0].');"><a href="'.get_permalink($feature->ID).'">'.get_img_html($feature->ID, 'feature').'</a></div>';
+
 			}
 
 			ob_start();
 			?>
 			<div class="<?=$css?>" id="feature">
 				<h2 class="indent">Featured Article</h2>
-				<div class="thumb cropped" style="background-image: url('<?=$attachment_url[0]?>');">
-					<?=$feature_media?>
-				</div>
+				<?=$feature_media?>
 				<h2 class="feature-title"><a href="<?=get_permalink($feature->ID)?>"><?=$feature->post_title?></a></h2>
 			</div>
 			<?

--- a/shortcodes.php
+++ b/shortcodes.php
@@ -269,7 +269,9 @@ function sc_feature($atts = Array(), $id_only = False)
 
 		$video_url = get_video_url($top_feature->ID);
 		if($video_url != '') {
-			$feature_media = '<div class="video-container" style="background-image: url('.$attachment_url[0].');">'.$wp_embed->run_shortcode('[embed width="380" height="500"]'.$video_url.'[/embed]</div>');
+			$feature_media = '<div class="video-container" style="background-image: url('.$attachment_url[0].');">'
+								.$wp_embed->run_shortcode('[embed width="380" height="313"]'.$video_url.'[/embed]').
+							'</div>';
 		} else {
 			$feature_media = '<a href="'.get_permalink($top_feature->ID).'">'.get_img_html($top_feature->ID, 'subpage_feature').'</a>';
 			$feature_media_attachment = get_img_html($top_feature->ID, 'subpage_feature', array('return_id' => true));

--- a/shortcodes.php
+++ b/shortcodes.php
@@ -274,18 +274,24 @@ function sc_feature($atts = Array(), $id_only = False)
 		if($id_only) return $top_feature->ID;
 
 		$video_url = get_video_url($top_feature->ID);
-		if($video_url != '') {
-			$feature_media = '<div class="video-container" style="background-image: url('.$attachment_url[0].');">'
-								.$wp_embed->run_shortcode('[embed width="380" height="313"]'.$video_url.'[/embed]').
-							'</div>';
-		} else {
+
+		ob_start();
+
+		if($video_url != '') :
+		?>
+		<div class="video-container" style="background-image: url('.$attachment_url[0].');">'
+			<?=$wp_embed->run_shortcode('[embed width="417" height="343"]'.$video_url.'[/embed]')?>
+		</div>
+		<?
+		$feature_media = ob_get_clean();
+		else :
 			$feature_media = '<a href="'.get_permalink($top_feature->ID).'">'.get_img_html($top_feature->ID, 'subpage_feature').'</a>';
 			$feature_media_attachment = get_img_html($top_feature->ID, 'subpage_feature', array('return_id' => true));
 			$attachment_url = wp_get_attachment_image_src($feature_media_attachment['attachment_id'], 'subpage_feature');
 			if (!$attachment_url) {
 				$attachment_url = array(0 => THEME_IMG_URL.'/no-photo.png');
 			}
-		}
+		endif;
 
 		ob_start();
 		?>

--- a/shortcodes.php
+++ b/shortcodes.php
@@ -228,18 +228,24 @@ function sc_feature($atts = Array(), $id_only = False)
 				$attachment_url = array(0 => THEME_IMG_URL.'/no-photo.png');
 			}
 
-			if($video_url != '') {
-				$feature_media = '<div class="video-container" style="background-image: url('.$attachment_url[0].');">'
-									.$wp_embed->run_shortcode('[embed width="417" height="343"]'.$video_url.'[/embed]').
-								'</div>';
-			} else {
-				$feature_media = '<div class="thumb cropped" style="background-image: url('.$attachment_url[0].');">
-									<a href="'.get_permalink($feature->ID).'">
-										'.get_img_html($feature->ID, 'feature').
-									'</a>
-								</div>';
+			ob_start();
 
-			}
+			if($video_url != '') :
+			?>
+			<div class="video-container" style="background-image: url('.$attachment_url[0].');">'
+				<?=$wp_embed->run_shortcode('[embed width="417" height="343"]'.$video_url.'[/embed]')?>
+			</div>
+			<? else :
+			?>
+			<div class="thumb cropped" style="background-image: url('.$attachment_url[0].');">
+				<a href="'.get_permalink($feature->ID).'">
+					<?=get_img_html($feature->ID, 'feature')?>
+				</a>
+			</div>
+			<?
+			endif;
+
+			$feature_media = ob_get_clean();
 
 			ob_start();
 			?>

--- a/shortcodes.php
+++ b/shortcodes.php
@@ -232,14 +232,14 @@ function sc_feature($atts = Array(), $id_only = False)
 
 			if($video_url != '') :
 			?>
-			<div class="video-container" style="background-image: url('<?=$attachment_url[0]?>');">
-				<?=$wp_embed->run_shortcode('[embed width="417" height="343"]'.$video_url.'[/embed]')?>
+			<div class="video-container" style="background-image: url('<?php echo $attachment_url[0]?>');">
+				<?php echo $wp_embed->run_shortcode('[embed width="417" height="343"]'.$video_url.'[/embed]')?>
 			</div>
 			<? else :
 			?>
-			<div class="thumb cropped" style="background-image: url('<?=$attachment_url[0]?>');">
-				<a href="<?=get_permalink($feature->ID)?>">
-					<?=get_img_html($feature->ID, 'feature')?>
+			<div class="thumb cropped" style="background-image: url('<?php echo $attachment_url[0]?>');">
+				<a href="<?php echo get_permalink($feature->ID)?>">
+					<?php echo get_img_html($feature->ID, 'feature')?>
 				</a>
 			</div>
 			<?
@@ -249,10 +249,10 @@ function sc_feature($atts = Array(), $id_only = False)
 
 			ob_start();
 			?>
-			<div class="<?=$css?>" id="feature">
+			<div class="<?php echo $css?>" id="feature">
 				<h2 class="indent">Featured Article</h2>
-				<?=$feature_media?>
-				<h2 class="feature-title"><a href="<?=get_permalink($feature->ID)?>"><?=$feature->post_title?></a></h2>
+				<?php echo $feature_media?>
+				<h2 class="feature-title"><a href="<?php echo get_permalink($feature->ID)?>"><?php echo $feature->post_title?></a></h2>
 			</div>
 			<?
 			return ob_get_clean();
@@ -284,15 +284,15 @@ function sc_feature($atts = Array(), $id_only = False)
 		if($video_url != '') :
 		?>
 		<div class="span5">
-			<div class="video-container" style="background-image: url('<?=$attachment_url[0]?>');">
-				<?=$wp_embed->run_shortcode('[embed width="417" height="343"]'.$video_url.'[/embed]')?>
+			<div class="video-container" style="background-image: url('<?php echo $attachment_url[0]?>');">
+				<?php echo $wp_embed->run_shortcode('[embed width="417" height="343"]'.$video_url.'[/embed]')?>
 			</div>
 		</div>
 		<? else :
 		?>
-		<div class="span5" style="background-image: url('<?=$attachment_url[0]?>');">
-			<a href="<?=get_permalink($top_feature->ID)?>">
-				<?=get_img_html($top_feature->ID, 'subpage_feature')?>
+		<div class="span5" style="background-image: url('<?php echo $attachment_url[0]?>');">
+			<a href="<?php echo get_permalink($top_feature->ID)?>">
+				<?php echo get_img_html($top_feature->ID, 'subpage_feature')?>
 			</a>
 		</div>
 		<? endif;

--- a/shortcodes.php
+++ b/shortcodes.php
@@ -238,7 +238,7 @@ function sc_feature($atts = Array(), $id_only = False)
 			<? else :
 			?>
 			<div class="thumb cropped" style="background-image: url('<?=$attachment_url[0]?>');">
-				<a href="'.get_permalink($feature->ID).'">
+				<a href="<?=get_permalink($feature->ID)?>">
 					<?=get_img_html($feature->ID, 'feature')?>
 				</a>
 			</div>
@@ -279,7 +279,6 @@ function sc_feature($atts = Array(), $id_only = False)
 		if (!$attachment_url) {
 			$attachment_url = array(0 => THEME_IMG_URL.'/no-photo.png');
 		}
-
 		ob_start();
 
 		if($video_url != '') :

--- a/shortcodes.php
+++ b/shortcodes.php
@@ -232,7 +232,7 @@ function sc_feature($atts = Array(), $id_only = False)
 
 			if($video_url != '') :
 			?>
-			<div class="video-container" style="background-image: url('<?=$attachment_url[0]?>');">'
+			<div class="video-container" style="background-image: url('<?=$attachment_url[0]?>');">
 				<?=$wp_embed->run_shortcode('[embed width="417" height="343"]'.$video_url.'[/embed]')?>
 			</div>
 			<? else :
@@ -274,32 +274,35 @@ function sc_feature($atts = Array(), $id_only = False)
 		if($id_only) return $top_feature->ID;
 
 		$video_url = get_video_url($top_feature->ID);
+		$feature_media_attachment = get_img_html($top_feature->ID, 'subpage_feature', array('return_id' => true));
+		$attachment_url = wp_get_attachment_image_src($feature_media_attachment['attachment_id'], 'subpage_feature');
+		if (!$attachment_url) {
+			$attachment_url = array(0 => THEME_IMG_URL.'/no-photo.png');
+		}
 
 		ob_start();
 
 		if($video_url != '') :
 		?>
-		<div class="video-container" style="background-image: url('<?=$attachment_url[0]?>');">'
-			<?=$wp_embed->run_shortcode('[embed width="417" height="343"]'.$video_url.'[/embed]')?>
+		<div class="span5">
+			<div class="video-container" style="background-image: url('<?=$attachment_url[0]?>');">
+				<?=$wp_embed->run_shortcode('[embed width="417" height="343"]'.$video_url.'[/embed]')?>
+			</div>
 		</div>
-		<?
+		<? else :
+		?>
+		<div class="span5" style="background-image: url('<?=$attachment_url[0]?>');">
+			<a href="<?=get_permalink($top_feature->ID)?>">
+				<?=get_img_html($top_feature->ID, 'subpage_feature')?>
+			</a>
+		</div>
+		<? endif;
 		$feature_media = ob_get_clean();
-		else :
-			$feature_media = '<a href="'.get_permalink($top_feature->ID).'">'.get_img_html($top_feature->ID, 'subpage_feature').'</a>';
-			$feature_media_attachment = get_img_html($top_feature->ID, 'subpage_feature', array('return_id' => true));
-			$attachment_url = wp_get_attachment_image_src($feature_media_attachment['attachment_id'], 'subpage_feature');
-			if (!$attachment_url) {
-				$attachment_url = array(0 => THEME_IMG_URL.'/no-photo.png');
-			}
-		endif;
-
 		ob_start();
 		?>
 		<div class="<?php echo $css ?>" id="feature">
 			<div class="row">
-				<div class="span5" style="background-image: url('<?php echo $attachment_url[0] ?>');">
-					<?php echo $feature_media ?>
-				</div>
+				<?php echo $feature_media ?>
 				<div class="span4">
 					<h2 class="feature-cat-title"><a href="<?php echo get_permalink( $top_feature->ID ) ?>"><?php echo $top_feature->post_title ?></a></h2>
 					<p class="story-blurb">

--- a/shortcodes.php
+++ b/shortcodes.php
@@ -263,7 +263,7 @@ function sc_feature($atts = Array(), $id_only = False)
 
 		$video_url = get_video_url($top_feature->ID);
 		if($video_url != '') {
-			$feature_media = $wp_embed->run_shortcode('[embed width="469" height="500"]'.$video_url.'[/embed]');
+			$feature_media = '<div class="video-container" style="background-image: url('.$attachment_url[0].');">'.$wp_embed->run_shortcode('[embed width="380" height="500"]'.$video_url.'[/embed]</div>');
 		} else {
 			$feature_media = '<a href="'.get_permalink($top_feature->ID).'">'.get_img_html($top_feature->ID, 'subpage_feature').'</a>';
 			$feature_media_attachment = get_img_html($top_feature->ID, 'subpage_feature', array('return_id' => true));

--- a/shortcodes.php
+++ b/shortcodes.php
@@ -229,9 +229,15 @@ function sc_feature($atts = Array(), $id_only = False)
 			}
 
 			if($video_url != '') {
-				$feature_media = '<div class="video-container" style="background-image: url('.$attachment_url[0].');">'.$wp_embed->run_shortcode('[embed width="417" height="343"]'.$video_url.'[/embed]</div>');
+				$feature_media = '<div class="video-container" style="background-image: url('.$attachment_url[0].');">'
+									.$wp_embed->run_shortcode('[embed width="417" height="343"]'.$video_url.'[/embed]').
+								'</div>';
 			} else {
-				$feature_media = '<div class="thumb cropped" style="background-image: url('.$attachment_url[0].');"><a href="'.get_permalink($feature->ID).'">'.get_img_html($feature->ID, 'feature').'</a></div>';
+				$feature_media = '<div class="thumb cropped" style="background-image: url('.$attachment_url[0].');">
+									<a href="'.get_permalink($feature->ID).'">
+										'.get_img_html($feature->ID, 'feature').
+									'</a>
+								</div>';
 
 			}
 

--- a/style.css
+++ b/style.css
@@ -681,10 +681,10 @@ ul.result-list li h3 { margin-bottom: 5px; }
 	padding-bottom: 56.25%;
 	padding-top: 30px;
 	height: 0;
-  overflow: hidden;
-  background-size: cover;
-  background-position: center center;
-  background-repeat: no-repeat;
+	overflow: hidden;
+	background-size: cover;
+  	background-position: center center;
+  	background-repeat: no-repeat;
 }
 
 .video-container iframe,

--- a/style.css
+++ b/style.css
@@ -681,7 +681,10 @@ ul.result-list li h3 { margin-bottom: 5px; }
 	padding-bottom: 56.25%;
 	padding-top: 30px;
 	height: 0;
-	overflow: hidden;
+  overflow: hidden;
+  background-size: cover;
+  background-position: center center;
+  background-repeat: no-repeat;
 }
 
 .video-container iframe,


### PR DESCRIPTION
Fixes:

- Moved $feature_media_attachment  and $attachment_url so that the featured image of the post is retrieved whether or not there is an input in the 'Video URL' for the post
- Wrapped the embedded video with a div.video-container so that the responsive styles are given to the video both on the front page and other pages the story is a feature (ex: topic pages)
- Moved the wrapping of the div.thumb.cropped to the $feature_media under the else statement so that the video isn't wrapped with those classes (they were causing the video to moved off-screen)
- Added background-image styles to the .video-container class so that the featured image is loaded and styled correctly if the video does not load and when the story is displayed under non-featured spots
