### PR TITLE
Caption Shortcode Fix

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -424,20 +424,6 @@ function get_excerpt($post, $hl_term = '')
 
 
 /**
- * Strip post content of <a><img></a> and [caption]???[/caption]
- *
- * @return string
- * @author Chris Conover
- **/
-function strip_img_caption($content)
-{
-	$content = preg_replace('/\[caption[^\]]*\][^\[]+\[\/caption\]/', '', $content);
-	return $content;
-}
-add_filter('the_content', 'strip_img_caption');
-
-
-/**
  * Check to see if the post has the mainsite tag associated with it
  * before it is edited. Used to check maintsite tag permissions after
  * the post is saved in check_mainsite_tag()

--- a/shortcodes.php
+++ b/shortcodes.php
@@ -962,18 +962,6 @@ function sc_single_post($atts = Array())
 	$content = apply_filters('the_content', $content);
 	$content = str_replace(']]>', ']]&gt;', $content);
 
-	# The story image might have been extacted from the content.
-	# If so remove, it and any surrounding links or captions.
-	$pattern = '/(\[caption[^\]]*\])?(<a[^>]*>)?<img[^>]*class="[^"]*wp-image-'.$attachment->ID.'[^"]*"[^>]*>(<\/a>)?(\[\/caption\])?/';
-	$content = preg_replace($pattern, '', $content);
-
-	# Sometimes a image has been inserted at the start of a story
-	# that isn't the featured image. Remove those too.
-	if(preg_match('/^<p>(<caption>)?(<a>)?<img/', $content)) {
-		$pattern = '/(\[caption[^\]]*\])?(<a[^>]*>)?<img[^>]*>(<\/a>)?(\[\/caption\])?/';
-		$content = preg_replace($pattern, '', $content);
-	}
-
 	$video_url = get_video_url($post->ID);
 
 	ob_start();

--- a/shortcodes.php
+++ b/shortcodes.php
@@ -981,7 +981,7 @@ function sc_single_post($atts = Array())
 			<? } ?>
 			<p id="caption"><?=( isset( $attachment ) ) ? $attachment->post_excerpt: ''?></p>
 			<div id="content">
-				<?=strip_tags( $content, '<p><a><ol><ul><li><em><strong><img><blockquote>' )?>
+				<?=strip_tags( $content, '<p><a><ol><ul><li><em><strong><img><blockquote><div>' )?>
 			</div>
 			<?=display_social( get_permalink( $post->ID ), $post->post_title )?>
 			<div id="share" role="form">

--- a/style-responsive.css
+++ b/style-responsive.css
@@ -280,8 +280,8 @@
 		line-height: 1.2em;
 	}
 
-  img.alignleft,
-  img.alignright {
+  .alignleft,
+  .alignright {
     margin: 0;
     min-width: 100%;
     float: none;

--- a/style.css
+++ b/style.css
@@ -1016,12 +1016,12 @@ body:not(:-moz-handler-blocked) #single #content > p:first-child:first-letter {
 .related-stories .span3:nth-child(4n+1) { margin-left: 0; }
 
 /* WordPress styles */
-img.alignleft {
+.alignleft {
   float: left;
   margin: 0 12px 12px 0;
 }
 
-img.alignright {
+.alignright {
   float: right;
   margin: 0 0 12px 12px;
 }

--- a/style.css
+++ b/style.css
@@ -789,7 +789,8 @@ ul.result-list li h3 { margin-bottom: 5px; }
 
 #single #subtitle { color: #666; font-size: 18px; }
 #single #story_feat_img { width: 100%; text-align: center; background: #f7f7f7; }
-#single p#caption {
+#single p#caption,
+#single p.wp-caption-text {
 	font-family: 'Helvetica Neue', 'Helvetica-Neue', Helvetica, sans-serif;
 	font-size: 12px;
 	line-height: 18px;


### PR DESCRIPTION
Adjustments:

- Removed 'strip_img_caption' function to prevent removal of images with captions
- Removed expressions that delete images and captioned images in a post if a featured image is not selected
- Added `<div>` as an allowed tag in a single post, so that images posted with captions can be generated in the div with the correct align- class
- Removed img specification for the .align styles so that caption divs with align classes are floated correctly in content
- Added .wp-caption-text style so that caption text is styled correctly within the content  