### PR TITLE
Homepage Featured Video Update

### DIFF
--- a/shortcodes.php
+++ b/shortcodes.php
@@ -221,37 +221,20 @@ function sc_feature($atts = Array(), $id_only = False)
 						'value' => 'featured'))));
 
 		if($feature !== False) {
-			$video_url = get_video_url($feature->ID);
 			$feature_media_attachment = get_img_html($feature->ID, 'feature', array('return_id' => true));
 			$attachment_url = wp_get_attachment_image_src($feature_media_attachment['attachment_id'], 'feature');
 			if (!$attachment_url) {
 				$attachment_url = array(0 => THEME_IMG_URL.'/no-photo.png');
 			}
-
-			ob_start();
-
-			if($video_url != '') :
-			?>
-			<div class="video-container" style="background-image: url('<?php echo $attachment_url[0]?>');">
-				<?php echo $wp_embed->run_shortcode('[embed width="417" height="343"]'.$video_url.'[/embed]')?>
-			</div>
-			<? else :
-			?>
-			<div class="thumb cropped" style="background-image: url('<?php echo $attachment_url[0]?>');">
-				<a href="<?php echo get_permalink($feature->ID)?>">
-					<?php echo get_img_html($feature->ID, 'feature')?>
-				</a>
-			</div>
-			<?
-			endif;
-
-			$feature_media = ob_get_clean();
+			$feature_media = '<a href="'.get_permalink($feature->ID).'">'.get_img_html($feature->ID, 'feature').'</a>';
 
 			ob_start();
 			?>
 			<div class="<?php echo $css?>" id="feature">
 				<h2 class="indent">Featured Article</h2>
-				<?php echo $feature_media?>
+				<div class="thumb cropped" style="background-image: url('<?php echo $attachment_url[0]?>');">
+					<?php echo $feature_media?>
+				</div>
 				<h2 class="feature-title"><a href="<?php echo get_permalink($feature->ID)?>"><?php echo $feature->post_title?></a></h2>
 			</div>
 			<?
@@ -273,35 +256,21 @@ function sc_feature($atts = Array(), $id_only = False)
 										Array('numberposts' => 1));
 		if($id_only) return $top_feature->ID;
 
-		$video_url = get_video_url($top_feature->ID);
 		$feature_media_attachment = get_img_html($top_feature->ID, 'subpage_feature', array('return_id' => true));
 		$attachment_url = wp_get_attachment_image_src($feature_media_attachment['attachment_id'], 'subpage_feature');
 		if (!$attachment_url) {
 			$attachment_url = array(0 => THEME_IMG_URL.'/no-photo.png');
 		}
+		$feature_media = '<a href="'.get_permalink($feature->ID).'">'.get_img_html($feature->ID, 'feature').'</a>';
+
 		ob_start();
 
-		if($video_url != '') :
-		?>
-		<div class="span5">
-			<div class="video-container" style="background-image: url('<?php echo $attachment_url[0]?>');">
-				<?php echo $wp_embed->run_shortcode('[embed width="417" height="343"]'.$video_url.'[/embed]')?>
-			</div>
-		</div>
-		<? else :
-		?>
-		<div class="span5" style="background-image: url('<?php echo $attachment_url[0]?>');">
-			<a href="<?php echo get_permalink($top_feature->ID)?>">
-				<?php echo get_img_html($top_feature->ID, 'subpage_feature')?>
-			</a>
-		</div>
-		<? endif;
-		$feature_media = ob_get_clean();
-		ob_start();
 		?>
 		<div class="<?php echo $css ?>" id="feature">
 			<div class="row">
-				<?php echo $feature_media ?>
+				<div class="span5" style="background-image: url('<?php echo $attachment_url[0]?>');">
+					<?php echo $feature_media ?>
+				</div>
 				<div class="span4">
 					<h2 class="feature-cat-title"><a href="<?php echo get_permalink( $top_feature->ID ) ?>"><?php echo $top_feature->post_title ?></a></h2>
 					<p class="story-blurb">

--- a/shortcodes.php
+++ b/shortcodes.php
@@ -233,7 +233,7 @@ function sc_feature($atts = Array(), $id_only = False)
 			<div class="<?php echo $css?>" id="feature">
 				<h2 class="indent">Featured Article</h2>
 				<div class="thumb cropped" style="background-image: url('<?php echo $attachment_url[0]?>');">
-					<?php echo $feature_media?>
+					<?php echo $feature_media; ?>
 				</div>
 				<h2 class="feature-title"><a href="<?php echo get_permalink($feature->ID)?>"><?php echo $feature->post_title?></a></h2>
 			</div>
@@ -269,7 +269,7 @@ function sc_feature($atts = Array(), $id_only = False)
 		<div class="<?php echo $css ?>" id="feature">
 			<div class="row">
 				<div class="span5" style="background-image: url('<?php echo $attachment_url[0]?>');">
-					<?php echo $feature_media ?>
+					<?php echo $feature_media; ?>
 				</div>
 				<div class="span4">
 					<h2 class="feature-cat-title"><a href="<?php echo get_permalink( $top_feature->ID ) ?>"><?php echo $top_feature->post_title ?></a></h2>


### PR DESCRIPTION
Updates:

- Removed if statement for video output on home, category and tag pages. The featured image will be shown on those pages even if the post has a Video URL set 
_(per Roger's request: Can we use the featured image as the thumbnail instead of embedding the video (on the homepage and topics/category pages). It'll be better for users to click the image and get into the story vs. watching the video without going into the story.)_