### PR TITLE
Removed post from Template Post Type to prevent selection in current …

### DIFF
--- a/featured-single-post.php
+++ b/featured-single-post.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Template Name: Featured Post
- * Template Post Type: post
+ * Template Post Type:
  */
 disallow_direct_load( 'featured-single-post.php' );
 get_header( 'featured' ); the_post();


### PR DESCRIPTION
To prevent the feature template from being available for users at this point, we're removing the post designation from the template. We can ready it when it's ready to go up.