### PR TITLE
Add GMUCF Options Page and API Endpoint

### DIFF
--- a/dev/acf-export.json
+++ b/dev/acf-export.json
@@ -1,0 +1,623 @@
+[
+    {
+        "key": "group_5be4b0336d8e2",
+        "title": "GMUCF Options Page",
+        "fields": [
+            {
+                "key": "field_5be4b17257873",
+                "label": "Email Send Date",
+                "name": "gmucf_email_send_date",
+                "type": "date_picker",
+                "instructions": "Select the date this email is set to send out. If this date is not set to the same date the email sends out, <b>a fallback email will be sent out<\/b>.",
+                "required": 1,
+                "conditional_logic": 0,
+                "wrapper": {
+                    "width": "50",
+                    "class": "",
+                    "id": ""
+                },
+                "display_format": "m\/d\/Y",
+                "return_format": "m\/d\/Y",
+                "first_day": 1
+            },
+            {
+                "key": "field_5be4b21557875",
+                "label": "Show Social Share Buttons",
+                "name": "gmucf_show_social_share_buttons",
+                "type": "true_false",
+                "instructions": "If checked, the social share buttons for each story will be displayed underneath the story's description text.",
+                "required": 0,
+                "conditional_logic": 0,
+                "wrapper": {
+                    "width": "50",
+                    "class": "",
+                    "id": ""
+                },
+                "message": "",
+                "default_value": 1,
+                "ui": 0,
+                "ui_on_text": "",
+                "ui_off_text": ""
+            },
+            {
+                "key": "field_5be59b0c672fa",
+                "label": "Top Stories",
+                "name": "gmucf_top_stories",
+                "type": "flexible_content",
+                "instructions": "",
+                "required": 0,
+                "conditional_logic": 0,
+                "wrapper": {
+                    "width": "",
+                    "class": "",
+                    "id": ""
+                },
+                "layouts": {
+                    "5be59b13ac2a4": {
+                        "key": "5be59b13ac2a4",
+                        "name": "gmucf_top_story",
+                        "label": "Top Story",
+                        "display": "block",
+                        "sub_fields": [
+                            {
+                                "key": "field_5be59b3f672fb",
+                                "label": "Select a Story",
+                                "name": "gmucf_story",
+                                "type": "post_object",
+                                "instructions": "Select a story to use for this top story.",
+                                "required": 1,
+                                "conditional_logic": 0,
+                                "wrapper": {
+                                    "width": "",
+                                    "class": "",
+                                    "id": ""
+                                },
+                                "post_type": [
+                                    "post"
+                                ],
+                                "taxonomy": [],
+                                "allow_null": 0,
+                                "multiple": 0,
+                                "return_format": "id",
+                                "ui": 1
+                            },
+                            {
+                                "key": "field_5be59cfe67300",
+                                "label": "Story Image",
+                                "name": "gmucf_story_image",
+                                "type": "image",
+                                "instructions": "",
+                                "required": 0,
+                                "conditional_logic": 0,
+                                "wrapper": {
+                                    "width": "",
+                                    "class": "",
+                                    "id": ""
+                                },
+                                "return_format": "array",
+                                "preview_size": "gmucf_top_story",
+                                "library": "all",
+                                "min_width": "",
+                                "min_height": "",
+                                "min_size": "",
+                                "max_width": "",
+                                "max_height": "",
+                                "max_size": "",
+                                "mime_types": ""
+                            },
+                            {
+                                "key": "field_5be59cd2672ff",
+                                "label": "Story Title",
+                                "name": "gmucf_story_title",
+                                "type": "text",
+                                "instructions": "Insert title here",
+                                "required": 0,
+                                "conditional_logic": 0,
+                                "wrapper": {
+                                    "width": "",
+                                    "class": "",
+                                    "id": ""
+                                },
+                                "default_value": "",
+                                "placeholder": "",
+                                "prepend": "",
+                                "append": "",
+                                "maxlength": ""
+                            },
+                            {
+                                "key": "field_5be59dc167301",
+                                "label": "Story Description",
+                                "name": "gmucf_story_description",
+                                "type": "textarea",
+                                "instructions": "",
+                                "required": 0,
+                                "conditional_logic": 0,
+                                "wrapper": {
+                                    "width": "",
+                                    "class": "",
+                                    "id": ""
+                                },
+                                "default_value": "",
+                                "placeholder": "",
+                                "maxlength": "",
+                                "rows": 4,
+                                "new_lines": ""
+                            }
+                        ],
+                        "min": "1",
+                        "max": ""
+                    }
+                },
+                "button_label": "Add Top Story",
+                "min": "",
+                "max": ""
+            },
+            {
+                "key": "field_5be5a17ce4cc9",
+                "label": "Featured Stories",
+                "name": "gmucf_featured_stories",
+                "type": "flexible_content",
+                "instructions": "Add an even number of stories here to be used in the featured stories section.",
+                "required": 0,
+                "conditional_logic": 0,
+                "wrapper": {
+                    "width": "",
+                    "class": "",
+                    "id": ""
+                },
+                "layouts": {
+                    "5be59b13ac2a4": {
+                        "key": "5be59b13ac2a4",
+                        "name": "gmucf_featured_story",
+                        "label": "Featured Story",
+                        "display": "block",
+                        "sub_fields": [
+                            {
+                                "key": "field_5be5a17ce4cca",
+                                "label": "Select a Story",
+                                "name": "gmucf_story",
+                                "type": "post_object",
+                                "instructions": "Select a story to use for this featured story.",
+                                "required": 1,
+                                "conditional_logic": 0,
+                                "wrapper": {
+                                    "width": "",
+                                    "class": "",
+                                    "id": ""
+                                },
+                                "post_type": [
+                                    "post"
+                                ],
+                                "taxonomy": [],
+                                "allow_null": 0,
+                                "multiple": 0,
+                                "return_format": "id",
+                                "ui": 1
+                            },
+                            {
+                                "key": "field_5be5a17ce4cce",
+                                "label": "Story Image",
+                                "name": "gmucf_story_image",
+                                "type": "image",
+                                "instructions": "",
+                                "required": 0,
+                                "conditional_logic": 0,
+                                "wrapper": {
+                                    "width": "",
+                                    "class": "",
+                                    "id": ""
+                                },
+                                "return_format": "array",
+                                "preview_size": "gmucf_featured_story",
+                                "library": "all",
+                                "min_width": "",
+                                "min_height": "",
+                                "min_size": "",
+                                "max_width": "",
+                                "max_height": "",
+                                "max_size": "",
+                                "mime_types": ""
+                            },
+                            {
+                                "key": "field_5be5a17ce4ccf",
+                                "label": "Story Title",
+                                "name": "gmucf_story_title",
+                                "type": "text",
+                                "instructions": "Insert title here",
+                                "required": 0,
+                                "conditional_logic": 0,
+                                "wrapper": {
+                                    "width": "",
+                                    "class": "",
+                                    "id": ""
+                                },
+                                "default_value": "",
+                                "placeholder": "",
+                                "prepend": "",
+                                "append": "",
+                                "maxlength": ""
+                            },
+                            {
+                                "key": "field_5be5a17ce4cd0",
+                                "label": "Story Description",
+                                "name": "gmucf_story_description",
+                                "type": "textarea",
+                                "instructions": "",
+                                "required": 0,
+                                "conditional_logic": 0,
+                                "wrapper": {
+                                    "width": "",
+                                    "class": "",
+                                    "id": ""
+                                },
+                                "default_value": "",
+                                "placeholder": "",
+                                "maxlength": "",
+                                "rows": 4,
+                                "new_lines": ""
+                            }
+                        ],
+                        "min": "2",
+                        "max": ""
+                    }
+                },
+                "button_label": "Add Featured Story",
+                "min": "",
+                "max": ""
+            }
+        ],
+        "location": [
+            [
+                {
+                    "param": "options_page",
+                    "operator": "==",
+                    "value": "gmucf-email"
+                }
+            ]
+        ],
+        "menu_order": 0,
+        "position": "normal",
+        "style": "default",
+        "label_placement": "top",
+        "instruction_placement": "label",
+        "hide_on_screen": "",
+        "active": 1,
+        "description": ""
+    },
+    {
+        "key": "group_5be5fd670dcaf",
+        "title": "GMUCF Options Page (copy)",
+        "fields": [
+            {
+                "key": "field_5be5fd67174cc",
+                "label": "Email Send Date",
+                "name": "gmucf_email_send_date",
+                "type": "date_picker",
+                "instructions": "Select the date this email is set to send out. If this date is not set to the same date the email sends out, <b>a fallback email will be sent out<\/b>.",
+                "required": 1,
+                "conditional_logic": 0,
+                "wrapper": {
+                    "width": "50",
+                    "class": "",
+                    "id": ""
+                },
+                "display_format": "m\/d\/Y",
+                "return_format": "m\/d\/Y",
+                "first_day": 1
+            },
+            {
+                "key": "field_5be5fd67174e6",
+                "label": "Show Social Share Buttons",
+                "name": "gmucf_show_social_share_buttons",
+                "type": "true_false",
+                "instructions": "If checked, the social share buttons for each story will be displayed underneath the story's description text.",
+                "required": 0,
+                "conditional_logic": 0,
+                "wrapper": {
+                    "width": "50",
+                    "class": "",
+                    "id": ""
+                },
+                "message": "",
+                "default_value": 1,
+                "ui": 0,
+                "ui_on_text": "",
+                "ui_off_text": ""
+            },
+            {
+                "key": "field_5be5fd816ee47",
+                "label": "Email Content",
+                "name": "gmucf_email_content",
+                "type": "flexible_content",
+                "instructions": "Select and order the email content. Select <strong>at least<\/strong> one Top Story and two Featured Stories. The amount of Featured Stories selected <strong>must be an even number<\/strong> and since the featured stories are displayed in the email in two columns, there must be two featured stories next to each other.",
+                "required": 0,
+                "conditional_logic": 0,
+                "wrapper": {
+                    "width": "",
+                    "class": "",
+                    "id": ""
+                },
+                "layouts": {
+                    "5be5fd915fd9d": {
+                        "key": "5be5fd915fd9d",
+                        "name": "gmucf_top_story",
+                        "label": "Top Story",
+                        "display": "block",
+                        "sub_fields": [
+                            {
+                                "key": "field_5be5fdb56ee48",
+                                "label": "Select a Story",
+                                "name": "gmucf_story",
+                                "type": "post_object",
+                                "instructions": "",
+                                "required": 0,
+                                "conditional_logic": 0,
+                                "wrapper": {
+                                    "width": "",
+                                    "class": "",
+                                    "id": ""
+                                },
+                                "post_type": [
+                                    "post",
+                                    "photoset"
+                                ],
+                                "taxonomy": [],
+                                "allow_null": 0,
+                                "multiple": 0,
+                                "return_format": "object",
+                                "ui": 1
+                            },
+                            {
+                                "key": "field_5be5fefc6ee49",
+                                "label": "Story Image",
+                                "name": "gmucf_story_image",
+                                "type": "image",
+                                "instructions": "If you do not want to use the story's featured image to display in the email, select an image to replace it here.",
+                                "required": 0,
+                                "conditional_logic": 0,
+                                "wrapper": {
+                                    "width": "",
+                                    "class": "",
+                                    "id": ""
+                                },
+                                "return_format": "",
+                                "preview_size": "gmucf_top_story",
+                                "library": "",
+                                "min_width": "",
+                                "min_height": "",
+                                "min_size": "",
+                                "max_width": "",
+                                "max_height": "",
+                                "max_size": "",
+                                "mime_types": "jpg, jpeg"
+                            },
+                            {
+                                "key": "field_5be5ff5b6ee4a",
+                                "label": "Story Title",
+                                "name": "gmucf_story_title",
+                                "type": "text",
+                                "instructions": "Replace the story's default title.",
+                                "required": 0,
+                                "conditional_logic": 0,
+                                "wrapper": {
+                                    "width": "",
+                                    "class": "",
+                                    "id": ""
+                                },
+                                "default_value": "",
+                                "placeholder": "",
+                                "prepend": "",
+                                "append": "",
+                                "maxlength": ""
+                            },
+                            {
+                                "key": "field_5be5ff8c6ee4b",
+                                "label": "Story Description",
+                                "name": "gmucf_story_description",
+                                "type": "textarea",
+                                "instructions": "Replace the story's promo field value here.",
+                                "required": 0,
+                                "conditional_logic": 0,
+                                "wrapper": {
+                                    "width": "",
+                                    "class": "",
+                                    "id": ""
+                                },
+                                "default_value": "",
+                                "placeholder": "",
+                                "maxlength": "",
+                                "rows": "",
+                                "new_lines": ""
+                            }
+                        ],
+                        "min": "1",
+                        "max": ""
+                    },
+                    "5be5ffbb6ee4c": {
+                        "key": "5be5ffbb6ee4c",
+                        "name": "gmucf_featured_story",
+                        "label": "Featured Story",
+                        "display": "block",
+                        "sub_fields": [
+                            {
+                                "key": "field_5be5ffbb6ee4d",
+                                "label": "Select a Story",
+                                "name": "gmucf_story",
+                                "type": "post_object",
+                                "instructions": "",
+                                "required": 0,
+                                "conditional_logic": 0,
+                                "wrapper": {
+                                    "width": "",
+                                    "class": "",
+                                    "id": ""
+                                },
+                                "post_type": [
+                                    "post"
+                                ],
+                                "taxonomy": [],
+                                "allow_null": 0,
+                                "multiple": 0,
+                                "return_format": "id",
+                                "ui": 1
+                            },
+                            {
+                                "key": "field_5be5ffbb6ee4e",
+                                "label": "Story Image",
+                                "name": "gmucf_story_image",
+                                "type": "image",
+                                "instructions": "If you do not want to use the story's featured image to display in the email, select an image to replace it here.",
+                                "required": 0,
+                                "conditional_logic": 0,
+                                "wrapper": {
+                                    "width": "",
+                                    "class": "",
+                                    "id": ""
+                                },
+                                "return_format": "url",
+                                "preview_size": "gmucf_top_story",
+                                "library": "all",
+                                "min_width": "",
+                                "min_height": "",
+                                "min_size": "",
+                                "max_width": "",
+                                "max_height": "",
+                                "max_size": "",
+                                "mime_types": "jpg, jpeg"
+                            },
+                            {
+                                "key": "field_5be5ffbb6ee4f",
+                                "label": "Story Title",
+                                "name": "gmucf_story_title",
+                                "type": "text",
+                                "instructions": "Replace the story's default title.",
+                                "required": 0,
+                                "conditional_logic": 0,
+                                "wrapper": {
+                                    "width": "",
+                                    "class": "",
+                                    "id": ""
+                                },
+                                "default_value": "",
+                                "placeholder": "",
+                                "prepend": "",
+                                "append": "",
+                                "maxlength": ""
+                            },
+                            {
+                                "key": "field_5be5ffbb6ee50",
+                                "label": "Story Description",
+                                "name": "gmucf_story_description",
+                                "type": "textarea",
+                                "instructions": "Replace the story's promo field value here.",
+                                "required": 0,
+                                "conditional_logic": 0,
+                                "wrapper": {
+                                    "width": "",
+                                    "class": "",
+                                    "id": ""
+                                },
+                                "default_value": "",
+                                "placeholder": "",
+                                "maxlength": "",
+                                "rows": "",
+                                "new_lines": ""
+                            }
+                        ],
+                        "min": "2",
+                        "max": ""
+                    },
+                    "5be5fff46ee51": {
+                        "key": "5be5fff46ee51",
+                        "name": "spotlight",
+                        "label": "Spotlight",
+                        "display": "block",
+                        "sub_fields": [
+                            {
+                                "key": "field_5be600be6ee52",
+                                "label": "Spotlight Image",
+                                "name": "gmucf_spotlight_image",
+                                "type": "image",
+                                "instructions": "Select an image to use as the spotlight. The image <strong>must be<\/strong> 600px wide. The height can vary.",
+                                "required": 1,
+                                "conditional_logic": 0,
+                                "wrapper": {
+                                    "width": "",
+                                    "class": "",
+                                    "id": ""
+                                },
+                                "return_format": "url",
+                                "preview_size": "gmucf_top_story",
+                                "library": "all",
+                                "min_width": "",
+                                "min_height": "",
+                                "min_size": "",
+                                "max_width": 600,
+                                "max_height": "",
+                                "max_size": "",
+                                "mime_types": "jpg, jpeg"
+                            },
+                            {
+                                "key": "field_5be601316ee53",
+                                "label": "Spotlight Link",
+                                "name": "gmucf_spotlight_link",
+                                "type": "url",
+                                "instructions": "",
+                                "required": 1,
+                                "conditional_logic": 0,
+                                "wrapper": {
+                                    "width": "",
+                                    "class": "",
+                                    "id": ""
+                                },
+                                "default_value": "",
+                                "placeholder": ""
+                            },
+                            {
+                                "key": "field_5be601706ee54",
+                                "label": "Spotlight Alt Text",
+                                "name": "gmucf_spotlight_alt_text",
+                                "type": "text",
+                                "instructions": "Enter the alternative text for the spotlight image here. Describe what the image is of and any text in the image. This text will also be used in the text only version of the email.",
+                                "required": 1,
+                                "conditional_logic": 0,
+                                "wrapper": {
+                                    "width": "",
+                                    "class": "",
+                                    "id": ""
+                                },
+                                "default_value": "",
+                                "placeholder": "",
+                                "prepend": "",
+                                "append": "",
+                                "maxlength": ""
+                            }
+                        ],
+                        "min": "",
+                        "max": "2"
+                    }
+                },
+                "button_label": "Add Row",
+                "min": "",
+                "max": ""
+            }
+        ],
+        "location": [
+            [
+                {
+                    "param": "options_page",
+                    "operator": "==",
+                    "value": "gmucf-email"
+                }
+            ]
+        ],
+        "menu_order": 0,
+        "position": "normal",
+        "style": "default",
+        "label_placement": "top",
+        "instruction_placement": "label",
+        "hide_on_screen": "",
+        "active": 1,
+        "description": ""
+    }
+]

--- a/dev/acf-export.json
+++ b/dev/acf-export.json
@@ -1,299 +1,14 @@
 [
     {
-        "key": "group_5be4b0336d8e2",
-        "title": "GMUCF Options Page",
-        "fields": [
-            {
-                "key": "field_5be4b17257873",
-                "label": "Email Send Date",
-                "name": "gmucf_email_send_date",
-                "type": "date_picker",
-                "instructions": "Select the date this email is set to send out. If this date is not set to the same date the email sends out, <b>a fallback email will be sent out<\/b>.",
-                "required": 1,
-                "conditional_logic": 0,
-                "wrapper": {
-                    "width": "50",
-                    "class": "",
-                    "id": ""
-                },
-                "display_format": "m\/d\/Y",
-                "return_format": "m\/d\/Y",
-                "first_day": 1
-            },
-            {
-                "key": "field_5be4b21557875",
-                "label": "Show Social Share Buttons",
-                "name": "gmucf_show_social_share_buttons",
-                "type": "true_false",
-                "instructions": "If checked, the social share buttons for each story will be displayed underneath the story's description text.",
-                "required": 0,
-                "conditional_logic": 0,
-                "wrapper": {
-                    "width": "50",
-                    "class": "",
-                    "id": ""
-                },
-                "message": "",
-                "default_value": 1,
-                "ui": 0,
-                "ui_on_text": "",
-                "ui_off_text": ""
-            },
-            {
-                "key": "field_5be59b0c672fa",
-                "label": "Top Stories",
-                "name": "gmucf_top_stories",
-                "type": "flexible_content",
-                "instructions": "",
-                "required": 0,
-                "conditional_logic": 0,
-                "wrapper": {
-                    "width": "",
-                    "class": "",
-                    "id": ""
-                },
-                "layouts": {
-                    "5be59b13ac2a4": {
-                        "key": "5be59b13ac2a4",
-                        "name": "gmucf_top_story",
-                        "label": "Top Story",
-                        "display": "block",
-                        "sub_fields": [
-                            {
-                                "key": "field_5be59b3f672fb",
-                                "label": "Select a Story",
-                                "name": "gmucf_story",
-                                "type": "post_object",
-                                "instructions": "Select a story to use for this top story.",
-                                "required": 1,
-                                "conditional_logic": 0,
-                                "wrapper": {
-                                    "width": "",
-                                    "class": "",
-                                    "id": ""
-                                },
-                                "post_type": [
-                                    "post"
-                                ],
-                                "taxonomy": [],
-                                "allow_null": 0,
-                                "multiple": 0,
-                                "return_format": "id",
-                                "ui": 1
-                            },
-                            {
-                                "key": "field_5be59cfe67300",
-                                "label": "Story Image",
-                                "name": "gmucf_story_image",
-                                "type": "image",
-                                "instructions": "",
-                                "required": 0,
-                                "conditional_logic": 0,
-                                "wrapper": {
-                                    "width": "",
-                                    "class": "",
-                                    "id": ""
-                                },
-                                "return_format": "array",
-                                "preview_size": "gmucf_top_story",
-                                "library": "all",
-                                "min_width": "",
-                                "min_height": "",
-                                "min_size": "",
-                                "max_width": "",
-                                "max_height": "",
-                                "max_size": "",
-                                "mime_types": ""
-                            },
-                            {
-                                "key": "field_5be59cd2672ff",
-                                "label": "Story Title",
-                                "name": "gmucf_story_title",
-                                "type": "text",
-                                "instructions": "Insert title here",
-                                "required": 0,
-                                "conditional_logic": 0,
-                                "wrapper": {
-                                    "width": "",
-                                    "class": "",
-                                    "id": ""
-                                },
-                                "default_value": "",
-                                "placeholder": "",
-                                "prepend": "",
-                                "append": "",
-                                "maxlength": ""
-                            },
-                            {
-                                "key": "field_5be59dc167301",
-                                "label": "Story Description",
-                                "name": "gmucf_story_description",
-                                "type": "textarea",
-                                "instructions": "",
-                                "required": 0,
-                                "conditional_logic": 0,
-                                "wrapper": {
-                                    "width": "",
-                                    "class": "",
-                                    "id": ""
-                                },
-                                "default_value": "",
-                                "placeholder": "",
-                                "maxlength": "",
-                                "rows": 4,
-                                "new_lines": ""
-                            }
-                        ],
-                        "min": "1",
-                        "max": ""
-                    }
-                },
-                "button_label": "Add Top Story",
-                "min": "",
-                "max": ""
-            },
-            {
-                "key": "field_5be5a17ce4cc9",
-                "label": "Featured Stories",
-                "name": "gmucf_featured_stories",
-                "type": "flexible_content",
-                "instructions": "Add an even number of stories here to be used in the featured stories section.",
-                "required": 0,
-                "conditional_logic": 0,
-                "wrapper": {
-                    "width": "",
-                    "class": "",
-                    "id": ""
-                },
-                "layouts": {
-                    "5be59b13ac2a4": {
-                        "key": "5be59b13ac2a4",
-                        "name": "gmucf_featured_story",
-                        "label": "Featured Story",
-                        "display": "block",
-                        "sub_fields": [
-                            {
-                                "key": "field_5be5a17ce4cca",
-                                "label": "Select a Story",
-                                "name": "gmucf_story",
-                                "type": "post_object",
-                                "instructions": "Select a story to use for this featured story.",
-                                "required": 1,
-                                "conditional_logic": 0,
-                                "wrapper": {
-                                    "width": "",
-                                    "class": "",
-                                    "id": ""
-                                },
-                                "post_type": [
-                                    "post"
-                                ],
-                                "taxonomy": [],
-                                "allow_null": 0,
-                                "multiple": 0,
-                                "return_format": "id",
-                                "ui": 1
-                            },
-                            {
-                                "key": "field_5be5a17ce4cce",
-                                "label": "Story Image",
-                                "name": "gmucf_story_image",
-                                "type": "image",
-                                "instructions": "",
-                                "required": 0,
-                                "conditional_logic": 0,
-                                "wrapper": {
-                                    "width": "",
-                                    "class": "",
-                                    "id": ""
-                                },
-                                "return_format": "array",
-                                "preview_size": "gmucf_featured_story",
-                                "library": "all",
-                                "min_width": "",
-                                "min_height": "",
-                                "min_size": "",
-                                "max_width": "",
-                                "max_height": "",
-                                "max_size": "",
-                                "mime_types": ""
-                            },
-                            {
-                                "key": "field_5be5a17ce4ccf",
-                                "label": "Story Title",
-                                "name": "gmucf_story_title",
-                                "type": "text",
-                                "instructions": "Insert title here",
-                                "required": 0,
-                                "conditional_logic": 0,
-                                "wrapper": {
-                                    "width": "",
-                                    "class": "",
-                                    "id": ""
-                                },
-                                "default_value": "",
-                                "placeholder": "",
-                                "prepend": "",
-                                "append": "",
-                                "maxlength": ""
-                            },
-                            {
-                                "key": "field_5be5a17ce4cd0",
-                                "label": "Story Description",
-                                "name": "gmucf_story_description",
-                                "type": "textarea",
-                                "instructions": "",
-                                "required": 0,
-                                "conditional_logic": 0,
-                                "wrapper": {
-                                    "width": "",
-                                    "class": "",
-                                    "id": ""
-                                },
-                                "default_value": "",
-                                "placeholder": "",
-                                "maxlength": "",
-                                "rows": 4,
-                                "new_lines": ""
-                            }
-                        ],
-                        "min": "2",
-                        "max": ""
-                    }
-                },
-                "button_label": "Add Featured Story",
-                "min": "",
-                "max": ""
-            }
-        ],
-        "location": [
-            [
-                {
-                    "param": "options_page",
-                    "operator": "==",
-                    "value": "gmucf-email"
-                }
-            ]
-        ],
-        "menu_order": 0,
-        "position": "normal",
-        "style": "default",
-        "label_placement": "top",
-        "instruction_placement": "label",
-        "hide_on_screen": "",
-        "active": 1,
-        "description": ""
-    },
-    {
         "key": "group_5be5fd670dcaf",
-        "title": "GMUCF Options Page (copy)",
+        "title": "GMUCF Options Page",
         "fields": [
             {
                 "key": "field_5be5fd67174cc",
                 "label": "Email Send Date",
                 "name": "gmucf_email_send_date",
                 "type": "date_picker",
-                "instructions": "Select the date this email is set to send out. If this date is not set to the same date the email sends out, <b>a fallback email will be sent out<\/b>.",
+                "instructions": "Select the date this email is set to send out. <strong style=\"color: red;\">If this date is not set to the same date the email is set to send out, a fallback email will be sent out.<\/strong>",
                 "required": 1,
                 "conditional_logic": 0,
                 "wrapper": {
@@ -303,14 +18,14 @@
                 },
                 "display_format": "m\/d\/Y",
                 "return_format": "m\/d\/Y",
-                "first_day": 1
+                "first_day": 0
             },
             {
                 "key": "field_5be5fd67174e6",
                 "label": "Show Social Share Buttons",
                 "name": "gmucf_show_social_share_buttons",
                 "type": "true_false",
-                "instructions": "If checked, the social share buttons for each story will be displayed underneath the story's description text.",
+                "instructions": "If checked, the social share buttons for each story will be displayed underneath the description text.",
                 "required": 0,
                 "conditional_logic": 0,
                 "wrapper": {
@@ -329,7 +44,7 @@
                 "label": "Email Content",
                 "name": "gmucf_email_content",
                 "type": "flexible_content",
-                "instructions": "Select and order the email content. Select <strong>at least<\/strong> one Top Story and two Featured Stories. The amount of Featured Stories selected <strong>must be an even number<\/strong> and since the featured stories are displayed in the email in two columns, there must be two featured stories next to each other.",
+                "instructions": "Select and order the email content.\r\n<br><br>\r\nSelect <strong>at least<\/strong> one Top Story and two Featured Stories. The amount of Featured Stories selected <strong>must be an even number<\/strong> and since the featured stories are displayed in the email in two columns, there <strong>must be two featured stories next to each other<\/strong>.\r\n<br><br>\r\nSpotlights can be added but are not required. There is a maximum of 2 spotlights per email.\r\n<br><br>\r\nPhoto sets can be selected from either the Top Story or Featured Stories options.",
                 "required": 0,
                 "conditional_logic": 0,
                 "wrapper": {
@@ -372,7 +87,7 @@
                                 "label": "Story Image",
                                 "name": "gmucf_story_image",
                                 "type": "image",
-                                "instructions": "If you do not want to use the story's featured image to display in the email, select an image to replace it here.",
+                                "instructions": "Select an image to replace the story's featured image in the email. The width must be 600px. The height can vary but we recommend keeping it around 300px. Make sure to optimize the images before uploading.",
                                 "required": 0,
                                 "conditional_logic": 0,
                                 "wrapper": {
@@ -380,13 +95,13 @@
                                     "class": "",
                                     "id": ""
                                 },
-                                "return_format": "",
-                                "preview_size": "gmucf_top_story",
-                                "library": "",
-                                "min_width": "",
+                                "return_format": "array",
+                                "preview_size": "full",
+                                "library": "all",
+                                "min_width": 600,
                                 "min_height": "",
                                 "min_size": "",
-                                "max_width": "",
+                                "max_width": 600,
                                 "max_height": "",
                                 "max_size": "",
                                 "mime_types": "jpg, jpeg"
@@ -396,7 +111,7 @@
                                 "label": "Story Title",
                                 "name": "gmucf_story_title",
                                 "type": "text",
-                                "instructions": "Replace the story's default title.",
+                                "instructions": "This will replace the story's title in the email.",
                                 "required": 0,
                                 "conditional_logic": 0,
                                 "wrapper": {
@@ -415,7 +130,7 @@
                                 "label": "Story Description",
                                 "name": "gmucf_story_description",
                                 "type": "textarea",
-                                "instructions": "Replace the story's promo field value here.",
+                                "instructions": "This will replace the story's Deck field value in the email.",
                                 "required": 0,
                                 "conditional_logic": 0,
                                 "wrapper": {
@@ -453,7 +168,8 @@
                                     "id": ""
                                 },
                                 "post_type": [
-                                    "post"
+                                    "post",
+                                    "photoset"
                                 ],
                                 "taxonomy": [],
                                 "allow_null": 0,
@@ -466,7 +182,7 @@
                                 "label": "Story Image",
                                 "name": "gmucf_story_image",
                                 "type": "image",
-                                "instructions": "If you do not want to use the story's featured image to display in the email, select an image to replace it here.",
+                                "instructions": "Select an image to replace the story's featured image in the email. The width must be 600px. The height can vary but we recommend keeping it around 300px. Make sure to optimize the images before uploading.",
                                 "required": 0,
                                 "conditional_logic": 0,
                                 "wrapper": {
@@ -475,12 +191,12 @@
                                     "id": ""
                                 },
                                 "return_format": "url",
-                                "preview_size": "gmucf_top_story",
+                                "preview_size": "full",
                                 "library": "all",
-                                "min_width": "",
+                                "min_width": 600,
                                 "min_height": "",
                                 "min_size": "",
-                                "max_width": "",
+                                "max_width": 600,
                                 "max_height": "",
                                 "max_size": "",
                                 "mime_types": "jpg, jpeg"
@@ -490,7 +206,7 @@
                                 "label": "Story Title",
                                 "name": "gmucf_story_title",
                                 "type": "text",
-                                "instructions": "Replace the story's default title.",
+                                "instructions": "This will replace the story's title in the email.",
                                 "required": 0,
                                 "conditional_logic": 0,
                                 "wrapper": {
@@ -509,7 +225,7 @@
                                 "label": "Story Description",
                                 "name": "gmucf_story_description",
                                 "type": "textarea",
-                                "instructions": "Replace the story's promo field value here.",
+                                "instructions": "This will replace the story's Deck field value in the email.",
                                 "required": 0,
                                 "conditional_logic": 0,
                                 "wrapper": {
@@ -538,7 +254,7 @@
                                 "label": "Spotlight Image",
                                 "name": "gmucf_spotlight_image",
                                 "type": "image",
-                                "instructions": "Select an image to use as the spotlight. The image <strong>must be<\/strong> 600px wide. The height can vary.",
+                                "instructions": "Select an image to use as the spotlight. The width must be 600px. The height can vary. Make sure to optimize the images before uploading.",
                                 "required": 1,
                                 "conditional_logic": 0,
                                 "wrapper": {
@@ -547,9 +263,9 @@
                                     "id": ""
                                 },
                                 "return_format": "url",
-                                "preview_size": "gmucf_top_story",
+                                "preview_size": "full",
                                 "library": "all",
-                                "min_width": "",
+                                "min_width": 600,
                                 "min_height": "",
                                 "min_size": "",
                                 "max_width": 600,
@@ -562,7 +278,7 @@
                                 "label": "Spotlight Link",
                                 "name": "gmucf_spotlight_link",
                                 "type": "url",
-                                "instructions": "",
+                                "instructions": "Enter the URL that users will be directed to when clicking on the spotlight image.",
                                 "required": 1,
                                 "conditional_logic": 0,
                                 "wrapper": {
@@ -578,7 +294,7 @@
                                 "label": "Spotlight Alt Text",
                                 "name": "gmucf_spotlight_alt_text",
                                 "type": "text",
-                                "instructions": "Enter the alternative text for the spotlight image here. Describe what the image is of and any text in the image. This text will also be used in the text only version of the email.",
+                                "instructions": "Enter the alternative text for the spotlight image here. Describe what the image is of and any text in the image. This text will also be used in the text only version of the email, so make sure it's descriptive.",
                                 "required": 1,
                                 "conditional_logic": 0,
                                 "wrapper": {
@@ -597,7 +313,7 @@
                         "max": "2"
                     }
                 },
-                "button_label": "Add Row",
+                "button_label": "Add Content",
                 "min": "",
                 "max": ""
             }
@@ -613,7 +329,7 @@
         ],
         "menu_order": 0,
         "position": "normal",
-        "style": "default",
+        "style": "seamless",
         "label_placement": "top",
         "instruction_placement": "label",
         "hide_on_screen": "",

--- a/dev/acf-export.json
+++ b/dev/acf-export.json
@@ -79,7 +79,7 @@
                                 "taxonomy": [],
                                 "allow_null": 0,
                                 "multiple": 0,
-                                "return_format": "object",
+                                "return_format": "id",
                                 "ui": 1
                             },
                             {
@@ -87,7 +87,7 @@
                                 "label": "Story Image",
                                 "name": "gmucf_story_image",
                                 "type": "image",
-                                "instructions": "Select an image to replace the story's featured image in the email. The width must be 600px. The height can vary but we recommend keeping it around 300px. Make sure to optimize the images before uploading.",
+                                "instructions": "Select an image to replace the story's featured image in the email.",
                                 "required": 0,
                                 "conditional_logic": 0,
                                 "wrapper": {
@@ -98,10 +98,10 @@
                                 "return_format": "array",
                                 "preview_size": "full",
                                 "library": "all",
-                                "min_width": 600,
+                                "min_width": "",
                                 "min_height": "",
                                 "min_size": "",
-                                "max_width": 600,
+                                "max_width": "",
                                 "max_height": "",
                                 "max_size": "",
                                 "mime_types": "jpg, jpeg"
@@ -182,7 +182,7 @@
                                 "label": "Story Image",
                                 "name": "gmucf_story_image",
                                 "type": "image",
-                                "instructions": "Select an image to replace the story's featured image in the email. The width must be 600px. The height can vary but we recommend keeping it around 300px. Make sure to optimize the images before uploading.",
+                                "instructions": "Select an image to replace the story's featured image in the email.",
                                 "required": 0,
                                 "conditional_logic": 0,
                                 "wrapper": {
@@ -190,13 +190,13 @@
                                     "class": "",
                                     "id": ""
                                 },
-                                "return_format": "url",
+                                "return_format": "array",
                                 "preview_size": "full",
                                 "library": "all",
-                                "min_width": 600,
+                                "min_width": "",
                                 "min_height": "",
                                 "min_size": "",
-                                "max_width": 600,
+                                "max_width": "",
                                 "max_height": "",
                                 "max_size": "",
                                 "mime_types": "jpg, jpeg"
@@ -254,7 +254,7 @@
                                 "label": "Spotlight Image",
                                 "name": "gmucf_spotlight_image",
                                 "type": "image",
-                                "instructions": "Select an image to use as the spotlight. The width must be 600px. The height can vary. Make sure to optimize the images before uploading.",
+                                "instructions": "Select an image to use as the spotlight.",
                                 "required": 1,
                                 "conditional_logic": 0,
                                 "wrapper": {
@@ -262,13 +262,13 @@
                                     "class": "",
                                     "id": ""
                                 },
-                                "return_format": "url",
+                                "return_format": "array",
                                 "preview_size": "full",
                                 "library": "all",
-                                "min_width": 600,
+                                "min_width": "",
                                 "min_height": "",
                                 "min_size": "",
-                                "max_width": 600,
+                                "max_width": "",
                                 "max_height": "",
                                 "max_size": "",
                                 "mime_types": "jpg, jpeg"

--- a/dev/acf-export.json
+++ b/dev/acf-export.json
@@ -44,7 +44,7 @@
                 "label": "Email Content",
                 "name": "gmucf_email_content",
                 "type": "flexible_content",
-                "instructions": "Select and order the email content.\r\n<br><br>\r\nSelect <strong>at least<\/strong> one Top Story and two Featured Stories. The amount of Featured Stories selected <strong>must be an even number<\/strong> and since the featured stories are displayed in the email in two columns, there <strong>must be two featured stories next to each other<\/strong>.\r\n<br><br>\r\nSpotlights can be added but are not required. There is a maximum of 2 spotlights per email.\r\n<br><br>\r\nPhoto sets can be selected from either the Top Story or Featured Stories options.",
+                "instructions": "Select and order the email content.\r\n<br><br>\r\nSelect <strong>at least<\/strong> one Top Story and one Featured Stories Row. Each Featured Stories Row must have two featured stories selected; one in each column.\r\n<br><br>\r\nSpotlights can be added but are not required. There is a maximum of 2 spotlights per email.\r\n<br><br>\r\nPhoto sets can be selected from either the Top Story or Featured Stories options.",
                 "required": 0,
                 "conditional_logic": 0,
                 "wrapper": {
@@ -148,99 +148,218 @@
                         "min": "1",
                         "max": ""
                     },
-                    "5be5ffbb6ee4c": {
-                        "key": "5be5ffbb6ee4c",
-                        "name": "gmucf_featured_story",
-                        "label": "Featured Story",
+                    "5bef062b9758c": {
+                        "key": "5bef062b9758c",
+                        "name": "gmucf_featured_stories_row",
+                        "label": "Featured Stories Row",
                         "display": "block",
                         "sub_fields": [
                             {
-                                "key": "field_5be5ffbb6ee4d",
-                                "label": "Select a Story",
-                                "name": "gmucf_story",
-                                "type": "post_object",
+                                "key": "field_5bef1383868cc",
+                                "label": "Left Featured Story",
+                                "name": "gmucf_left_featured_story",
+                                "type": "group",
                                 "instructions": "",
                                 "required": 0,
                                 "conditional_logic": 0,
                                 "wrapper": {
-                                    "width": "",
+                                    "width": "50",
                                     "class": "",
                                     "id": ""
                                 },
-                                "post_type": [
-                                    "post",
-                                    "photoset"
-                                ],
-                                "taxonomy": [],
-                                "allow_null": 0,
-                                "multiple": 0,
-                                "return_format": "id",
-                                "ui": 1
+                                "layout": "block",
+                                "sub_fields": [
+                                    {
+                                        "key": "field_5bef069697592",
+                                        "label": "Select a Story",
+                                        "name": "gmucf_story",
+                                        "type": "post_object",
+                                        "instructions": "",
+                                        "required": 0,
+                                        "conditional_logic": 0,
+                                        "wrapper": {
+                                            "width": "",
+                                            "class": "",
+                                            "id": ""
+                                        },
+                                        "post_type": [
+                                            "post",
+                                            "photoset"
+                                        ],
+                                        "taxonomy": [],
+                                        "allow_null": 0,
+                                        "multiple": 0,
+                                        "return_format": "id",
+                                        "ui": 1
+                                    },
+                                    {
+                                        "key": "field_5bef06809758f",
+                                        "label": "Story Image",
+                                        "name": "gmucf_story_image",
+                                        "type": "image",
+                                        "instructions": "Select an image to replace the story's featured image in the email.",
+                                        "required": 0,
+                                        "conditional_logic": 0,
+                                        "wrapper": {
+                                            "width": "",
+                                            "class": "",
+                                            "id": ""
+                                        },
+                                        "return_format": "array",
+                                        "preview_size": "full",
+                                        "library": "all",
+                                        "min_width": "",
+                                        "min_height": "",
+                                        "min_size": "",
+                                        "max_width": "",
+                                        "max_height": "",
+                                        "max_size": "",
+                                        "mime_types": "jpg, jpeg"
+                                    },
+                                    {
+                                        "key": "field_5bef068497590",
+                                        "label": "Story Title",
+                                        "name": "gmucf_story_title",
+                                        "type": "text",
+                                        "instructions": "This will replace the story's title in the email.",
+                                        "required": 0,
+                                        "conditional_logic": 0,
+                                        "wrapper": {
+                                            "width": "",
+                                            "class": "",
+                                            "id": ""
+                                        },
+                                        "default_value": "",
+                                        "placeholder": "",
+                                        "prepend": "",
+                                        "append": "",
+                                        "maxlength": ""
+                                    },
+                                    {
+                                        "key": "field_5bef068697591",
+                                        "label": "Story Description",
+                                        "name": "gmucf_story_description",
+                                        "type": "textarea",
+                                        "instructions": "This will replace the story's Deck field value in the email.",
+                                        "required": 0,
+                                        "conditional_logic": 0,
+                                        "wrapper": {
+                                            "width": "",
+                                            "class": "",
+                                            "id": ""
+                                        },
+                                        "default_value": "",
+                                        "placeholder": "",
+                                        "maxlength": "",
+                                        "rows": "",
+                                        "new_lines": ""
+                                    }
+                                ]
                             },
                             {
-                                "key": "field_5be5ffbb6ee4e",
-                                "label": "Story Image",
-                                "name": "gmucf_story_image",
-                                "type": "image",
-                                "instructions": "Select an image to replace the story's featured image in the email.",
+                                "key": "field_5bef13d0868d1",
+                                "label": "Right Featured Story",
+                                "name": "gmucf_right_featured_story",
+                                "type": "group",
+                                "instructions": "",
                                 "required": 0,
                                 "conditional_logic": 0,
                                 "wrapper": {
-                                    "width": "",
+                                    "width": "50",
                                     "class": "",
                                     "id": ""
                                 },
-                                "return_format": "array",
-                                "preview_size": "full",
-                                "library": "all",
-                                "min_width": "",
-                                "min_height": "",
-                                "min_size": "",
-                                "max_width": "",
-                                "max_height": "",
-                                "max_size": "",
-                                "mime_types": "jpg, jpeg"
-                            },
-                            {
-                                "key": "field_5be5ffbb6ee4f",
-                                "label": "Story Title",
-                                "name": "gmucf_story_title",
-                                "type": "text",
-                                "instructions": "This will replace the story's title in the email.",
-                                "required": 0,
-                                "conditional_logic": 0,
-                                "wrapper": {
-                                    "width": "",
-                                    "class": "",
-                                    "id": ""
-                                },
-                                "default_value": "",
-                                "placeholder": "",
-                                "prepend": "",
-                                "append": "",
-                                "maxlength": ""
-                            },
-                            {
-                                "key": "field_5be5ffbb6ee50",
-                                "label": "Story Description",
-                                "name": "gmucf_story_description",
-                                "type": "textarea",
-                                "instructions": "This will replace the story's Deck field value in the email.",
-                                "required": 0,
-                                "conditional_logic": 0,
-                                "wrapper": {
-                                    "width": "",
-                                    "class": "",
-                                    "id": ""
-                                },
-                                "default_value": "",
-                                "placeholder": "",
-                                "maxlength": "",
-                                "rows": "",
-                                "new_lines": ""
+                                "layout": "block",
+                                "sub_fields": [
+                                    {
+                                        "key": "field_5bef13d1868d2",
+                                        "label": "Select a Story",
+                                        "name": "gmucf_story",
+                                        "type": "post_object",
+                                        "instructions": "",
+                                        "required": 0,
+                                        "conditional_logic": 0,
+                                        "wrapper": {
+                                            "width": "",
+                                            "class": "",
+                                            "id": ""
+                                        },
+                                        "post_type": [
+                                            "post",
+                                            "photoset"
+                                        ],
+                                        "taxonomy": [],
+                                        "allow_null": 0,
+                                        "multiple": 0,
+                                        "return_format": "id",
+                                        "ui": 1
+                                    },
+                                    {
+                                        "key": "field_5bef13d1868d3",
+                                        "label": "Story Image",
+                                        "name": "gmucf_story_image",
+                                        "type": "image",
+                                        "instructions": "Select an image to replace the story's featured image in the email.",
+                                        "required": 0,
+                                        "conditional_logic": 0,
+                                        "wrapper": {
+                                            "width": "",
+                                            "class": "",
+                                            "id": ""
+                                        },
+                                        "return_format": "array",
+                                        "preview_size": "full",
+                                        "library": "all",
+                                        "min_width": "",
+                                        "min_height": "",
+                                        "min_size": "",
+                                        "max_width": "",
+                                        "max_height": "",
+                                        "max_size": "",
+                                        "mime_types": "jpg, jpeg"
+                                    },
+                                    {
+                                        "key": "field_5bef13d1868d4",
+                                        "label": "Story Title",
+                                        "name": "gmucf_story_title",
+                                        "type": "text",
+                                        "instructions": "This will replace the story's title in the email.",
+                                        "required": 0,
+                                        "conditional_logic": 0,
+                                        "wrapper": {
+                                            "width": "",
+                                            "class": "",
+                                            "id": ""
+                                        },
+                                        "default_value": "",
+                                        "placeholder": "",
+                                        "prepend": "",
+                                        "append": "",
+                                        "maxlength": ""
+                                    },
+                                    {
+                                        "key": "field_5bef13d1868d5",
+                                        "label": "Story Description",
+                                        "name": "gmucf_story_description",
+                                        "type": "textarea",
+                                        "instructions": "This will replace the story's Deck field value in the email.",
+                                        "required": 0,
+                                        "conditional_logic": 0,
+                                        "wrapper": {
+                                            "width": "",
+                                            "class": "",
+                                            "id": ""
+                                        },
+                                        "default_value": "",
+                                        "placeholder": "",
+                                        "maxlength": "",
+                                        "rows": "",
+                                        "new_lines": ""
+                                    }
+                                ]
                             }
                         ],
-                        "min": "2",
+                        "min": "1",
                         "max": ""
                     },
                     "5be5fff46ee51": {

--- a/dev/acf-export.json
+++ b/dev/acf-export.json
@@ -245,7 +245,7 @@
                     },
                     "5be5fff46ee51": {
                         "key": "5be5fff46ee51",
-                        "name": "spotlight",
+                        "name": "gmucf_spotlight",
                         "label": "Spotlight",
                         "display": "block",
                         "sub_fields": [

--- a/dev/acf-export.json
+++ b/dev/acf-export.json
@@ -382,5 +382,45 @@
         "hide_on_screen": "",
         "active": 1,
         "description": ""
+    },
+    {
+        "key": "group_5bee32128a576",
+        "title": "Preview GMUCF Email",
+        "fields": [
+            {
+                "key": "field_5bee321a8437d",
+                "label": "",
+                "name": "",
+                "type": "message",
+                "instructions": "",
+                "required": 0,
+                "conditional_logic": 0,
+                "wrapper": {
+                    "width": "",
+                    "class": "",
+                    "id": ""
+                },
+                "message": "<p style=\"margin-top: 0;\">Click the button below to open the GMUCF email in a new tab. This page must be updated in order to see the latest changes.<\/p>\r\n<a href=\"https:\/\/gmucf.smca.ucf.edu\/news\/mail\/?no_cache=true\" target=\"_blank\" style=\"background: #fc0; padding: 8px; color: #000; text-decoration: none; font-weight: bold; display: block; text-align: center;\">Preview Email<\/a>",
+                "new_lines": "",
+                "esc_html": 0
+            }
+        ],
+        "location": [
+            [
+                {
+                    "param": "options_page",
+                    "operator": "==",
+                    "value": "gmucf-email"
+                }
+            ]
+        ],
+        "menu_order": 1,
+        "position": "side",
+        "style": "default",
+        "label_placement": "top",
+        "instruction_placement": "label",
+        "hide_on_screen": "",
+        "active": 1,
+        "description": ""
     }
 ]

--- a/functions.php
+++ b/functions.php
@@ -7,6 +7,7 @@ require_once('functions/admin.php');  			# Admin/login functions
 require_once('functions/config.php');			# Where per theme settings are registered
 require_once('functions/api.php');              # Custom wp-json points are defined here
 require_once('shortcodes.php');         		# Per theme shortcodes
+require_once('functions/gmucf-options.php');         		# GMUCF Options page and functions
 
 require_once('third-party/wp-rss-media.php');	# Add images and media tag to the RSS feed for the Widget
 

--- a/functions.php
+++ b/functions.php
@@ -1,15 +1,15 @@
 <?php
-require_once('functions/base.php');   			# Base theme functions
-require_once('functions/feeds.php');			# Where functions related to feed data live
-require_once('custom-taxonomies.php');  		# Where per theme taxonomies are defined
-require_once('custom-post-types.php');  		# Where per theme post types are defined
-require_once('functions/admin.php');  			# Admin/login functions
-require_once('functions/config.php');			# Where per theme settings are registered
+require_once('functions/base.php');             # Base theme functions
+require_once('functions/feeds.php');            # Where functions related to feed data live
+require_once('custom-taxonomies.php');          # Where per theme taxonomies are defined
+require_once('custom-post-types.php');          # Where per theme post types are defined
+require_once('functions/admin.php');            # Admin/login functions
+require_once('functions/config.php');           # Where per theme settings are registered
 require_once('functions/api.php');              # Custom wp-json points are defined here
-require_once('shortcodes.php');         		# Per theme shortcodes
+require_once('shortcodes.php');                 # Per theme shortcodes
 require_once('functions/gmucf-options.php');    # GMUCF Options page and functions
 
-require_once('third-party/wp-rss-media.php');	# Add images and media tag to the RSS feed for the Widget
+require_once('third-party/wp-rss-media.php');   # Add images and media tag to the RSS feed for the Widget
 
 
 //Add theme-specific functions here.

--- a/functions/api.php
+++ b/functions/api.php
@@ -184,10 +184,33 @@ if ( ! class_exists( 'UCF_Today_Custom_API' ) ) {
 			);
 
 			$retval['send_date']        = get_field( 'gmucf_email_send_date', 'option' );
-            $retval['social_share']     = get_field( 'gmucf_show_social_share_buttons', 'option' );
-			$retval['top_stories']      = gmucf_stories_default_values( get_field( 'gmucf_top_stories', 'option' ) );
-			$retval['featured_stories'] = gmucf_stories_default_values( get_field( 'gmucf_featured_stories', 'option' ) );
-			$retval['spotlights']       = get_field( 'gmucf_spotlights', 'option' );
+			$retval['social_share']     = get_field( 'gmucf_show_social_share_buttons', 'option' );
+
+			if ( have_rows( 'gmucf_email_content', 'option' ) ) :
+
+				while ( have_rows( 'gmucf_email_content', 'option' ) ) : the_row();
+
+					if ( get_row_layout() == 'gmucf_top_story' ) :
+
+						$retval['top_stories'][] = get_sub_field( 'gmucf_story' );
+
+					elseif ( get_row_layout() == 'gmucf_featured_story' ) :
+
+						$retval['featured_stories'][] = get_sub_field( 'gmucf_story' );
+
+					elseif ( get_row_layout() == 'gmucf_spotlight' ) :
+
+						$retval['spotlights'][] = get_sub_field( 'gmucf_spotlight_image' );
+
+					endif;
+
+				endwhile;
+
+			endif;
+
+			// $retval['top_stories']      = gmucf_stories_default_values( get_field( 'gmucf_top_stories', 'option' ) );
+			// $retval['featured_stories'] = gmucf_stories_default_values( get_field( 'gmucf_featured_stories', 'option' ) );
+			// $retval['spotlights']       = get_field( 'gmucf_spotlights', 'option' );
 
             return new WP_REST_Response( $retval, 200 );
         }

--- a/functions/api.php
+++ b/functions/api.php
@@ -184,43 +184,10 @@ if ( ! class_exists( 'UCF_Today_Custom_API' ) ) {
          * @return WP_REST_Response
          */
         public static function get_gmucf_email_options( $request ) {
+			$retval = get_fields( 'gmucf_options' );
 
-            $retval = array(
-                'send_date'        => '',
-				'social_share'     => '',
-				'top_stories'      => '',
-				'featured_stories' => '',
-				'spotlights'       => ''
-			);
-
-			$retval['send_date']        = get_field( 'gmucf_email_send_date', 'option' );
-			$retval['social_share']     = get_field( 'gmucf_show_social_share_buttons', 'option' );
-
-			if ( have_rows( 'gmucf_email_content', 'option' ) ) :
-
-				while ( have_rows( 'gmucf_email_content', 'option' ) ) : the_row();
-
-					if ( get_row_layout() == 'gmucf_top_story' ) :
-
-						$retval['top_stories'][] = get_sub_field( 'gmucf_story' );
-
-					elseif ( get_row_layout() == 'gmucf_featured_story' ) :
-
-						$retval['featured_stories'][] = get_sub_field( 'gmucf_story' );
-
-					elseif ( get_row_layout() == 'gmucf_spotlight' ) :
-
-						$retval['spotlights'][] = get_sub_field( 'gmucf_spotlight_image' );
-
-					endif;
-
-				endwhile;
-
-			endif;
-
-			// $retval['top_stories']      = gmucf_stories_default_values( get_field( 'gmucf_top_stories', 'option' ) );
-			// $retval['featured_stories'] = gmucf_stories_default_values( get_field( 'gmucf_featured_stories', 'option' ) );
-			// $retval['spotlights']       = get_field( 'gmucf_spotlights', 'option' );
+			$gmucf_content_rows            = $retval['gmucf_email_content'];
+			$retval['gmucf_email_content'] = gmucf_stories_default_values( $gmucf_content_rows );
 
             return new WP_REST_Response( $retval, 200 );
         }

--- a/functions/api.php
+++ b/functions/api.php
@@ -6,7 +6,7 @@
 if ( ! class_exists( 'UCF_Today_Custom_API' ) ) {
     class UCF_Today_Custom_API extends WP_REST_Controller {
         /**
-         * Regusters the rest routes for the ucf_news api
+         * Registers the rest routes for the ucf_news api
          * @since 2.8.0
          * @author Jim Barnes
          */
@@ -20,6 +20,14 @@ if ( ! class_exists( 'UCF_Today_Custom_API' ) ) {
                     'callback'             => array( 'UCF_Today_Custom_API', 'get_external_stories' ),
                     'permissions_callback' => array( 'UCF_Today_Custom_API', 'get_permissions' ),
                     'args'                 => array( 'UCF_Today_Custom_API', 'get_external_story_args' )
+                )
+			) );
+
+			register_rest_route( "{$root}/{$version}", "/gmucf-email-options", array(
+                array(
+                    'methods'              => WP_REST_Server::READABLE,
+                    'callback'             => array( 'UCF_Today_Custom_API', 'get_gmucf_email_options' ),
+                    'permissions_callback' => array( 'UCF_Today_Custom_API', 'get_permissions' )
                 )
             ) );
         }
@@ -156,6 +164,32 @@ if ( ! class_exists( 'UCF_Today_Custom_API' ) ) {
                     )
                 )
             );
+		}
+
+		/**
+         * Gets the GMUCF email options
+         * @since 2.9.0
+         * @author Cadie
+         * @param WP_REST_Request $request | Contains GET params
+         * @return WP_REST_Response
+         */
+        public static function get_gmucf_email_options( $request ) {
+
+            $retval = array(
+                'send_date'        => '',
+				'social_share'     => '',
+				'top_stories'      => '',
+				'featured_stories' => '',
+				'spotlights'       => ''
+			);
+
+			$retval['send_date']        = get_field( 'gmucf_email_send_date', 'option' );
+            $retval['social_share']     = get_field( 'gmucf_show_social_share_buttons', 'option' );
+			$retval['top_stories']      = gmucf_stories_default_values( get_field( 'gmucf_top_stories', 'option' ) );
+			$retval['featured_stories'] = gmucf_stories_default_values( get_field( 'gmucf_featured_stories', 'option' ) );
+			$retval['spotlights']       = get_field( 'gmucf_spotlights', 'option' );
+
+            return new WP_REST_Response( $retval, 200 );
         }
     }
 }

--- a/functions/api.php
+++ b/functions/api.php
@@ -4,192 +4,192 @@
  * within this file.
  */
 if ( ! class_exists( 'UCF_Today_Custom_API' ) ) {
-    class UCF_Today_Custom_API extends WP_REST_Controller {
-        /**
-         * Registers the rest routes for the ucf_news api
-         * @since 2.8.0
-         * @author Jim Barnes
-         */
-        public static function register_rest_routes() {
-            $root    = 'ucf-news';
-            $version = 'v1';
+	class UCF_Today_Custom_API extends WP_REST_Controller {
+		/**
+		 * Registers the rest routes for the ucf_news api
+		 * @since 2.8.0
+		 * @author Jim Barnes
+		 */
+		public static function register_rest_routes() {
+			$root    = 'ucf-news';
+			$version = 'v1';
 
-            register_rest_route( "{$root}/{$version}", "/external-stories", array(
-                array(
-                    'methods'              => WP_REST_Server::READABLE,
-                    'callback'             => array( 'UCF_Today_Custom_API', 'get_external_stories' ),
-                    'permissions_callback' => array( 'UCF_Today_Custom_API', 'get_permissions' ),
-                    'args'                 => array( 'UCF_Today_Custom_API', 'get_external_story_args' )
-                )
+			register_rest_route( "{$root}/{$version}", "/external-stories", array(
+				array(
+					'methods'              => WP_REST_Server::READABLE,
+					'callback'             => array( 'UCF_Today_Custom_API', 'get_external_stories' ),
+					'permissions_callback' => array( 'UCF_Today_Custom_API', 'get_permissions' ),
+					'args'                 => array( 'UCF_Today_Custom_API', 'get_external_story_args' )
+				)
 			) );
 
 			register_rest_route( "{$root}/{$version}", "/gmucf-email-options", array(
-                array(
-                    'methods'              => WP_REST_Server::READABLE,
-                    'callback'             => array( 'UCF_Today_Custom_API', 'get_gmucf_email_options' ),
-                    'permissions_callback' => array( 'UCF_Today_Custom_API', 'get_permissions' )
-                )
-            ) );
-        }
-
-        /**
-         * Gets the external stories
-         * @since 2.8.0
-         * @author Jim Barnes
-         * @param WP_REST_Request $request | Contains GET params
-         * @return WP_REST_Response
-         */
-        public static function get_external_stories( $request ) {
-            // Handle args and set defaults
-            $search     = $request['search'];
-            $source     = $request['source'];
-            $limit      = $request['limit'] ? $request['limit'] : 10;
-            $offset     = $request['offset'] ? $request['offset'] : 0;
-            $categories = $request['categories'];
-
-            // Initialize out return value
-            $retval = array();
-
-            // Initialize and set defaults on argument array
-            $args = array(
-                'post_type'      => 'externalstory',
-                'posts_per_page' => $limit,
-                'offset'         => $offset
-            );
-
-            // Add search if it's set
-            if ( $search ) {
-                $args['s'] = $search;
-            }
-
-            // Add source meta query if it's set
-            if ( $source ) {
-                $sources = explode( ',', $source );
-
-                $args['meta_query'] = array();
-
-                foreach ( $sources as $source ) {
-                    $args['meta_query'][] = array(
-                        'key'   => 'externalstory_source',
-                        'value' => $source
-                    );
-                }
-
-                if ( count( $args['meta_query'] ) > 1 ) {
-                    $args['meta_query']['relation'] = 'OR';
-                }
-            }
-
-            if ( $categories ) {
-                $args['category_name'] = $categories;
-            }
-
-            $posts = get_posts( $args );
-
-            foreach( $posts as $post ) {
-                $data     = self::prepare_external_story_for_response( $post, $request );
-                $retval[] = $data;
-            }
-
-            return new WP_REST_Response( $retval, 200 );
-        }
-
-        /**
-         * Formats the external story for response
-         * @since 2.8.0
-         * @author Jim Barnes
-         * @param WP_Post $post The post
-         * @param WP_REST_Request $request The request object
-         * @return array A serializable array.
-         */
-        private static function prepare_external_story_for_response( $post, $request ) {
-
-            $terms = wp_get_post_terms( $post->ID, 'sources' );
-            $field = ( !empty( $terms ) ) ? get_field( 'news_source_image', $terms[0] ) : null;
-            $source_image = ( !empty( $field ) ) ? $field['url'] : null;
-            $source_name = wp_get_post_terms( $post->ID, 'sources' );
-
-            // Prepare the return value format
-            $retval = array(
-                'title'        => '',
-                'link_text'    => '',
-                'description'  => '',
-                'url'          => '',
-                'source'       => '',
-                'source_name'  => '',
-                'source_image' => '',
-                'publish_date' => '',
-                'categories'   => array()
-            );
-
-            $retval['title']        = $post->post_title;
-            $retval['link_text']    = get_post_meta( $post->ID, 'externalstory_text', true );
-            $retval['description']  = get_post_meta( $post->ID, 'externalstory_description', true );
-            $retval['url']          = get_post_meta( $post->ID, 'externalstory_url', true );
-            $retval['source']       = get_post_meta( $post->ID, 'externalstory_source', true );
-            $retval['source_name']  = ( !empty( $source_name ) ) ? $source_name[0]->name : null;
-            $retval['source_image'] = $source_image;
-            $retval['publish_date'] = $post->post_date;
-            $retval['categories']   = wp_get_post_categories( $post->ID, array( 'fields' => 'names' ) );
-
-            return $retval;
-        }
-
-        /**
-         * Gets the default permissions
-         * @since 2.8.0
-         * @author Jim Barnes
-         */
-        public static function get_permissions() {
-            return true;
-        }
-
-        /**
-         * Gets the allowable args for external stories
-         * @since 2.8.0
-         * @author Jim Barnes
-         */
-        public static function get_external_story_args() {
-            return array(
-                array(
-                    'search' => array(
-                        'default'           => false,
-                        'sanitize_callback' => 'sanitize_text_field'
-                    ),
-                    'source' => array(
-                        'default'           => false,
-                        'sanitize_callback' => 'sanitize_text_field'
-                    ),
-                    'limit' => array(
-                        'default'           => 10,
-                        'sanitize_callback' => 'absint'
-                    ),
-                    'offset' => array(
-                        'default'           => 0,
-                        'sanitize_callback' => 'absint'
-                    ),
-                    'categories' => array(
-                        'default'           => false,
-                        'sanitize_callback' => 'sanitize_text_field'
-                    )
-                )
-            );
+				array(
+					'methods'              => WP_REST_Server::READABLE,
+					'callback'             => array( 'UCF_Today_Custom_API', 'get_gmucf_email_options' ),
+					'permissions_callback' => array( 'UCF_Today_Custom_API', 'get_permissions' )
+				)
+			) );
 		}
 
 		/**
-         * Gets the GMUCF email options
-         * @since 2.9.0
-         * @author Cadie
-         * @param WP_REST_Request $request | Contains GET params
-         * @return WP_REST_Response
-         */
-        public static function get_gmucf_email_options( $request ) {
+		 * Gets the external stories
+		 * @since 2.8.0
+		 * @author Jim Barnes
+		 * @param WP_REST_Request $request | Contains GET params
+		 * @return WP_REST_Response
+		 */
+		public static function get_external_stories( $request ) {
+			// Handle args and set defaults
+			$search     = $request['search'];
+			$source     = $request['source'];
+			$limit      = $request['limit'] ? $request['limit'] : 10;
+			$offset     = $request['offset'] ? $request['offset'] : 0;
+			$categories = $request['categories'];
+
+			// Initialize out return value
+			$retval = array();
+
+			// Initialize and set defaults on argument array
+			$args = array(
+				'post_type'      => 'externalstory',
+				'posts_per_page' => $limit,
+				'offset'         => $offset
+			);
+
+			// Add search if it's set
+			if ( $search ) {
+				$args['s'] = $search;
+			}
+
+			// Add source meta query if it's set
+			if ( $source ) {
+				$sources = explode( ',', $source );
+
+				$args['meta_query'] = array();
+
+				foreach ( $sources as $source ) {
+					$args['meta_query'][] = array(
+						'key'   => 'externalstory_source',
+						'value' => $source
+					);
+				}
+
+				if ( count( $args['meta_query'] ) > 1 ) {
+					$args['meta_query']['relation'] = 'OR';
+				}
+			}
+
+			if ( $categories ) {
+				$args['category_name'] = $categories;
+			}
+
+			$posts = get_posts( $args );
+
+			foreach( $posts as $post ) {
+				$data     = self::prepare_external_story_for_response( $post, $request );
+				$retval[] = $data;
+			}
+
+			return new WP_REST_Response( $retval, 200 );
+		}
+
+		/**
+		 * Formats the external story for response
+		 * @since 2.8.0
+		 * @author Jim Barnes
+		 * @param WP_Post $post The post
+		 * @param WP_REST_Request $request The request object
+		 * @return array A serializable array.
+		 */
+		private static function prepare_external_story_for_response( $post, $request ) {
+
+			$terms = wp_get_post_terms( $post->ID, 'sources' );
+			$field = ( !empty( $terms ) ) ? get_field( 'news_source_image', $terms[0] ) : null;
+			$source_image = ( !empty( $field ) ) ? $field['url'] : null;
+			$source_name = wp_get_post_terms( $post->ID, 'sources' );
+
+			// Prepare the return value format
+			$retval = array(
+				'title'        => '',
+				'link_text'    => '',
+				'description'  => '',
+				'url'          => '',
+				'source'       => '',
+				'source_name'  => '',
+				'source_image' => '',
+				'publish_date' => '',
+				'categories'   => array()
+			);
+
+			$retval['title']        = $post->post_title;
+			$retval['link_text']    = get_post_meta( $post->ID, 'externalstory_text', true );
+			$retval['description']  = get_post_meta( $post->ID, 'externalstory_description', true );
+			$retval['url']          = get_post_meta( $post->ID, 'externalstory_url', true );
+			$retval['source']       = get_post_meta( $post->ID, 'externalstory_source', true );
+			$retval['source_name']  = ( !empty( $source_name ) ) ? $source_name[0]->name : null;
+			$retval['source_image'] = $source_image;
+			$retval['publish_date'] = $post->post_date;
+			$retval['categories']   = wp_get_post_categories( $post->ID, array( 'fields' => 'names' ) );
+
+			return $retval;
+		}
+
+		/**
+		 * Gets the default permissions
+		 * @since 2.8.0
+		 * @author Jim Barnes
+		 */
+		public static function get_permissions() {
+			return true;
+		}
+
+		/**
+		 * Gets the allowable args for external stories
+		 * @since 2.8.0
+		 * @author Jim Barnes
+		 */
+		public static function get_external_story_args() {
+			return array(
+				array(
+					'search' => array(
+						'default'           => false,
+						'sanitize_callback' => 'sanitize_text_field'
+					),
+					'source' => array(
+						'default'           => false,
+						'sanitize_callback' => 'sanitize_text_field'
+					),
+					'limit' => array(
+						'default'           => 10,
+						'sanitize_callback' => 'absint'
+					),
+					'offset' => array(
+						'default'           => 0,
+						'sanitize_callback' => 'absint'
+					),
+					'categories' => array(
+						'default'           => false,
+						'sanitize_callback' => 'sanitize_text_field'
+					)
+				)
+			);
+		}
+
+		/**
+		 * Gets the GMUCF email options
+		 * @since 2.9.0
+		 * @author Cadie
+		 * @param WP_REST_Request $request | Contains GET params
+		 * @return WP_REST_Response
+		 */
+		public static function get_gmucf_email_options( $request ) {
 			$retval = get_fields( 'gmucf_options' );
 
 			$gmucf_content_rows            = $retval['gmucf_email_content'];
 			$retval['gmucf_email_content'] = gmucf_stories_default_values( $gmucf_content_rows );
 
-            return new WP_REST_Response( $retval, 200 );
-        }
-    }
+			return new WP_REST_Response( $retval, 200 );
+		}
+	}
 }

--- a/functions/gmucf-options.php
+++ b/functions/gmucf-options.php
@@ -20,11 +20,11 @@ if ( function_exists('acf_add_options_page') ) {
 }
 
 /**
- * Sets the default values for each stories image, title and
+ * Sets the default values for each stories' image, title and
  * description for use in the GMUCF Today emails
  * @since 2.9.0
  * @author Cadie Brown
- * @param Array $stories | Stories array from ACF GMUCF Options Page
+ * @param Array $stories | gmucf_email_content array from ACF GMUCF Options Page
  * @return Array
  */
 function gmucf_stories_default_values( $stories ) {

--- a/functions/gmucf-options.php
+++ b/functions/gmucf-options.php
@@ -20,6 +20,34 @@ if ( function_exists('acf_add_options_page') ) {
 }
 
 /**
+ * Sets the default values for each stories' image, title and
+ * description for use in the GMUCF Today emails
+ * @since 2.9.0
+ * @author Cadie Brown
+ * @param Array $story | single array with story data
+ * @return Array
+ */
+function gmucf_replace_story_default_values( $story ) {
+	$post_id = $story['gmucf_story'];
+
+	if ( ! $story['gmucf_story_image'] ) {
+		$story['gmucf_story_image'] = get_the_post_thumbnail_url( $post_id, 'gmucf_top_story' );
+	} else {
+		$story['gmucf_story_image'] = $story['gmucf_story_image']['sizes']['gmucf_top_story'];
+	}
+
+	if ( ! $story['gmucf_story_title'] ) {
+		$story['gmucf_story_title'] = get_the_title( $post_id );
+	}
+
+	if ( ! $story['gmucf_story_description'] ) {
+		$story['gmucf_story_description'] = get_post_meta( $post_id, 'promo', true );
+	}
+
+	return $story;
+}
+
+/**
  * Sets the default values depending on what kind
  * of layout is being used
  * @since 2.9.0
@@ -48,32 +76,4 @@ function gmucf_stories_default_values( $stories ) {
 	}
 
 	return $retval;
-}
-
-/**
- * Sets the default values for each stories' image, title and
- * description for use in the GMUCF Today emails
- * @since 2.9.0
- * @author Cadie Brown
- * @param Array $story | single array with story data
- * @return Array
- */
-function gmucf_replace_story_default_values( $story ) {
-	$post_id = $story['gmucf_story'];
-
-	if ( ! $story['gmucf_story_image'] ) {
-		$story['gmucf_story_image'] = get_the_post_thumbnail_url( $post_id, 'gmucf_top_story' );
-	} else {
-		$story['gmucf_story_image'] = $story['gmucf_story_image']['sizes']['gmucf_top_story'];
-	}
-
-	if ( ! $story['gmucf_story_title'] ) {
-		$story['gmucf_story_title'] = get_the_title( $post_id );
-	}
-
-	if ( ! $story['gmucf_story_description'] ) {
-		$story['gmucf_story_description'] = get_post_meta( $post_id, 'promo', true );
-	}
-
-	return $story;
 }

--- a/functions/gmucf-options.php
+++ b/functions/gmucf-options.php
@@ -7,12 +7,14 @@
 if ( function_exists('acf_add_options_page') ) {
 
 	acf_add_options_page(array(
-		'page_title' 	=> 'GMUCF Email',
-		'menu_title'	=> 'GMUCF Email',
-		'menu_slug' 	=> 'gmucf-email',
-		'capability'	=> 'editor',
-		'icon_url'      => 'dashicons-email-alt',
-		'redirect'      => false
+		'page_title' 	  => 'GMUCF Email',
+		'post_id'         => 'gmucf_options',
+		'menu_title'	  => 'GMUCF Email',
+		'menu_slug' 	  => 'gmucf-email',
+		'capability'	  => 'editor',
+		'icon_url'        => 'dashicons-email-alt',
+		'redirect'        => false,
+		'updated_message' => 'GMUCF Options Updated'
 	));
 
 }

--- a/functions/gmucf-options.php
+++ b/functions/gmucf-options.php
@@ -49,7 +49,7 @@ function gmucf_stories_default_values( $stories ) {
 			$retval[] = $story;
 		} elseif ( $story['acf_fc_layout'] == 'gmucf_spotlight' ) {
 			$story['gmucf_spotlight_image'] = $story['gmucf_spotlight_image']['sizes']['gmucf_top_story'];
-			
+
 			$retval[] = $story;
 		}
 	}

--- a/functions/gmucf-options.php
+++ b/functions/gmucf-options.php
@@ -29,21 +29,25 @@ if ( function_exists('acf_add_options_page') ) {
  */
 function gmucf_stories_default_values( $stories ) {
 	foreach ( $stories as $story ) {
-		$post_id = $story['gmucf_story'];
+		if ( $story['acf_fc_layout'] == 'gmucf_top_story' || $story['acf_fc_layout'] == 'gmucf_featured_story' ) {
+			$post_id = $story['gmucf_story'];
 
-		if ( ! $story['gmucf_story_image'] ) {
-			$story['gmucf_story_image'] = get_the_post_thumbnail_url( $post_id );
+			if ( ! $story['gmucf_story_image'] ) {
+				$story['gmucf_story_image'] = get_the_post_thumbnail_url( $post_id, 'gmucf_top_story' );
+			}
+
+			if ( ! $story['gmucf_story_title'] ) {
+				$story['gmucf_story_title'] = get_the_title( $post_id );
+			}
+
+			if ( ! $story['gmucf_story_description'] ) {
+				$story['gmucf_story_description'] = get_post_meta( $post_id, 'promo', true );
+			}
+
+			$retval[] = $story;
+		} else {
+			$retval[] = $story;
 		}
-
-		if ( ! $story['gmucf_story_title'] ) {
-			$story['gmucf_story_title'] = get_the_title( $post_id );
-		}
-
-		if ( ! $story['gmucf_story_description'] ) {
-			$story['gmucf_story_description'] = get_post_meta( $post_id, 'promo', true );
-		}
-
-		$retval[] = $story;
 	}
 
 	return $retval;

--- a/functions/gmucf-options.php
+++ b/functions/gmucf-options.php
@@ -16,3 +16,33 @@ if ( function_exists('acf_add_options_page') ) {
 	));
 
 }
+
+/**
+ * Sets the default values for each stories image, title and
+ * description for use in the GMUCF Today emails
+ * @since 2.9.0
+ * @author Cadie Brown
+ * @param Array $stories | Stories array from ACF GMUCF Options Page
+ * @return Array
+ */
+function gmucf_stories_default_values( $stories ) {
+	foreach ( $stories as $story ) {
+		$post_id = $story['gmucf_story'];
+
+		if ( ! $story['gmucf_story_image'] ) {
+			$story['gmucf_story_image'] = get_the_post_thumbnail_url( $post_id );
+		}
+
+		if ( ! $story['gmucf_story_title'] ) {
+			$story['gmucf_story_title'] = get_the_title( $post_id );
+		}
+
+		if ( ! $story['gmucf_story_description'] ) {
+			$story['gmucf_story_description'] = get_post_meta( $post_id, 'promo', true );
+		}
+
+		$retval[] = $story;
+	}
+
+	return $retval;
+}

--- a/functions/gmucf-options.php
+++ b/functions/gmucf-options.php
@@ -1,0 +1,18 @@
+<?php
+
+/**
+ * Adds the GMUCF Email options page if
+ * ACF Pro is installed
+ */
+if ( function_exists('acf_add_options_page') ) {
+
+	acf_add_options_page(array(
+		'page_title' 	=> 'GMUCF Email',
+		'menu_title'	=> 'GMUCF Email',
+		'menu_slug' 	=> 'gmucf-email',
+		'capability'	=> 'editor',
+		'icon_url'      => 'dashicons-email-alt',
+		'redirect'      => false
+	));
+
+}

--- a/functions/gmucf-options.php
+++ b/functions/gmucf-options.php
@@ -20,8 +20,8 @@ if ( function_exists('acf_add_options_page') ) {
 }
 
 /**
- * Sets the default values for each stories' image, title and
- * description for use in the GMUCF Today emails
+ * Sets the default values depending on what kind
+ * of layout is being used
  * @since 2.9.0
  * @author Cadie Brown
  * @param Array $stories | gmucf_email_content array from ACF GMUCF Options Page
@@ -29,30 +29,53 @@ if ( function_exists('acf_add_options_page') ) {
  */
 function gmucf_stories_default_values( $stories ) {
 	foreach ( $stories as $story ) {
-		if ( $story['acf_fc_layout'] == 'gmucf_top_story' || $story['acf_fc_layout'] == 'gmucf_featured_story' ) {
-			$post_id = $story['gmucf_story'];
-
-			if ( ! $story['gmucf_story_image'] ) {
-				$story['gmucf_story_image'] = get_the_post_thumbnail_url( $post_id, 'gmucf_top_story' );
-			} else {
-				$story['gmucf_story_image'] = $story['gmucf_story_image']['sizes']['gmucf_top_story'];
-			}
-
-			if ( ! $story['gmucf_story_title'] ) {
-				$story['gmucf_story_title'] = get_the_title( $post_id );
-			}
-
-			if ( ! $story['gmucf_story_description'] ) {
-				$story['gmucf_story_description'] = get_post_meta( $post_id, 'promo', true );
-			}
+		if ( $story['acf_fc_layout'] == 'gmucf_top_story' ) {
+			gmucf_replace_story_default_values( $story );
 
 			$retval[] = $story;
+		} elseif ( $story['acf_fc_layout'] == 'gmucf_featured_stories_row' ) {
+			// for both featured stories, add an 'acf_fc_layout' field with value of 'gmucf_featured_story' to the beginning of the array
+			$story['gmucf_left_featured_story']  = ['acf_fc_layout' => 'gmucf_featured_story'] + $story['gmucf_left_featured_story'];
+			$story['gmucf_right_featured_story'] = ['acf_fc_layout' => 'gmucf_featured_story'] + $story['gmucf_right_featured_story'];
+
+			$retval[] = gmucf_replace_story_default_values( $story['gmucf_left_featured_story'] );
+			$retval[] = gmucf_replace_story_default_values( $story['gmucf_right_featured_story'] );
 		} elseif ( $story['acf_fc_layout'] == 'gmucf_spotlight' ) {
 			$story['gmucf_spotlight_image'] = $story['gmucf_spotlight_image']['sizes']['gmucf_top_story'];
 
+			$retval[] = $story;
+		} else {
 			$retval[] = $story;
 		}
 	}
 
 	return $retval;
+}
+
+/**
+ * Sets the default values for each stories' image, title and
+ * description for use in the GMUCF Today emails
+ * @since 2.9.0
+ * @author Cadie Brown
+ * @param Array $story | single array with story data
+ * @return Array
+ */
+function gmucf_replace_story_default_values( $story ) {
+	$post_id = $story['gmucf_story'];
+
+	if ( ! $story['gmucf_story_image'] ) {
+		$story['gmucf_story_image'] = get_the_post_thumbnail_url( $post_id, 'gmucf_top_story' );
+	} else {
+		$story['gmucf_story_image'] = $story['gmucf_story_image']['sizes']['gmucf_top_story'];
+	}
+
+	if ( ! $story['gmucf_story_title'] ) {
+		$story['gmucf_story_title'] = get_the_title( $post_id );
+	}
+
+	if ( ! $story['gmucf_story_description'] ) {
+		$story['gmucf_story_description'] = get_post_meta( $post_id, 'promo', true );
+	}
+
+	return $story;
 }

--- a/functions/gmucf-options.php
+++ b/functions/gmucf-options.php
@@ -11,7 +11,7 @@ if ( function_exists('acf_add_options_page') ) {
 		'post_id'         => 'gmucf_options',
 		'menu_title'	  => 'GMUCF Email',
 		'menu_slug' 	  => 'gmucf-email',
-		'capability'	  => 'editor',
+		'capability'	  => 'administrator',
 		'icon_url'        => 'dashicons-email-alt',
 		'redirect'        => false,
 		'updated_message' => 'GMUCF Options Updated'

--- a/functions/gmucf-options.php
+++ b/functions/gmucf-options.php
@@ -34,6 +34,8 @@ function gmucf_stories_default_values( $stories ) {
 
 			if ( ! $story['gmucf_story_image'] ) {
 				$story['gmucf_story_image'] = get_the_post_thumbnail_url( $post_id, 'gmucf_top_story' );
+			} else {
+				$story['gmucf_story_image'] = $story['gmucf_story_image']['sizes']['gmucf_top_story'];
 			}
 
 			if ( ! $story['gmucf_story_title'] ) {
@@ -45,7 +47,9 @@ function gmucf_stories_default_values( $stories ) {
 			}
 
 			$retval[] = $story;
-		} else {
+		} elseif ( $story['acf_fc_layout'] == 'gmucf_spotlight' ) {
+			$story['gmucf_spotlight_image'] = $story['gmucf_spotlight_image']['sizes']['gmucf_top_story'];
+			
 			$retval[] = $story;
 		}
 	}

--- a/functions/gmucf-options.php
+++ b/functions/gmucf-options.php
@@ -57,16 +57,16 @@ function gmucf_replace_story_default_values( $story ) {
  */
 function gmucf_stories_default_values( $stories ) {
 	foreach ( $stories as $story ) {
-		if ( $story['acf_fc_layout'] == 'gmucf_top_story' ) {
+		if ( $story['acf_fc_layout'] === 'gmucf_top_story' ) {
 			$retval[] = gmucf_replace_story_default_values( $story );
-		} elseif ( $story['acf_fc_layout'] == 'gmucf_featured_stories_row' ) {
+		} elseif ( $story['acf_fc_layout'] === 'gmucf_featured_stories_row' ) {
 			// for both featured stories, add an 'acf_fc_layout' field with value of 'gmucf_featured_story' to the beginning of the array
 			$story['gmucf_left_featured_story']  = ['acf_fc_layout' => 'gmucf_featured_story'] + $story['gmucf_left_featured_story'];
 			$story['gmucf_right_featured_story'] = ['acf_fc_layout' => 'gmucf_featured_story'] + $story['gmucf_right_featured_story'];
 
 			$retval[] = gmucf_replace_story_default_values( $story['gmucf_left_featured_story'] );
 			$retval[] = gmucf_replace_story_default_values( $story['gmucf_right_featured_story'] );
-		} elseif ( $story['acf_fc_layout'] == 'gmucf_spotlight' ) {
+		} elseif ( $story['acf_fc_layout'] === 'gmucf_spotlight' ) {
 			$story['gmucf_spotlight_image'] = $story['gmucf_spotlight_image']['sizes']['gmucf_top_story'];
 
 			$retval[] = $story;

--- a/functions/gmucf-options.php
+++ b/functions/gmucf-options.php
@@ -30,9 +30,7 @@ if ( function_exists('acf_add_options_page') ) {
 function gmucf_stories_default_values( $stories ) {
 	foreach ( $stories as $story ) {
 		if ( $story['acf_fc_layout'] == 'gmucf_top_story' ) {
-			gmucf_replace_story_default_values( $story );
-
-			$retval[] = $story;
+			$retval[] = gmucf_replace_story_default_values( $story );
 		} elseif ( $story['acf_fc_layout'] == 'gmucf_featured_stories_row' ) {
 			// for both featured stories, add an 'acf_fc_layout' field with value of 'gmucf_featured_story' to the beginning of the array
 			$story['gmucf_left_featured_story']  = ['acf_fc_layout' => 'gmucf_featured_story'] + $story['gmucf_left_featured_story'];

--- a/readme.markdown
+++ b/readme.markdown
@@ -7,6 +7,7 @@ Theme to replace the original Today WordPress theme, which relies on the Themati
 ## Installation
 
 ### Required Plugins:
+* Advanced Custom Fields PRO
 * Social
 * Twitter Tools (requires Social)
 * UCF Social Plugin
@@ -31,6 +32,7 @@ The primary issue with Pingbacks, though, is that media attachments allow them, 
 * Create a menu named 'Top Navigation' with the appropriate navigation links.
 * Create a menu for the social media buttons and assign this menu to the 'Social Links' display location.
 * Ensure that the homepage display option is set to 'Your latest posts' in Reading Settings.
+* Import field groups (dev/acf-export.json) using the ACF importer under Custom Fields > Tools.
 
 
 ## Development


### PR DESCRIPTION
- Adds a GMUCF Email Options page through ACF with custom ACF fields that allow top stories, featured story rows and spotlights to be selected and moved around easily
- Adds the ACF GMUCF Email Options page selected values to `wp-json/ucf-news/v1/gmucf-email-options/`
- Before those values are added to the API, they are routed through functions that set default values for images, titles, and descriptions. These functions also select the `gmucf_top_story` image size for all images
- Updated readme to include ACF Pro dependency and configuration step