### PR TITLE
Update GMUCF Options Feed

### DIFF
--- a/dev/acf-export.json
+++ b/dev/acf-export.json
@@ -104,7 +104,7 @@
                                 "max_width": "",
                                 "max_height": "",
                                 "max_size": "",
-                                "mime_types": "jpg, jpeg"
+                                "mime_types": "jpg, jpeg, gif"
                             },
                             {
                                 "key": "field_5be5ff5b6ee4a",
@@ -214,7 +214,7 @@
                                         "max_width": "",
                                         "max_height": "",
                                         "max_size": "",
-                                        "mime_types": "jpg, jpeg"
+                                        "mime_types": "jpg, jpeg, gif"
                                     },
                                     {
                                         "key": "field_5bef068497590",
@@ -390,7 +390,7 @@
                                 "max_width": "",
                                 "max_height": "",
                                 "max_size": "",
-                                "mime_types": "jpg, jpeg"
+                                "mime_types": "jpg, jpeg, gif"
                             },
                             {
                                 "key": "field_5be601316ee53",

--- a/functions/gmucf-options.php
+++ b/functions/gmucf-options.php
@@ -65,14 +65,19 @@ function gmucf_stories_default_values( $stories ) {
 	foreach ( $stories as $story ) {
 		if ( $story['acf_fc_layout'] === 'gmucf_top_story' ) {
 			$retval[] = gmucf_replace_story_default_values( $story );
-		} elseif ( $story['acf_fc_layout'] === 'gmucf_featured_stories_row' ) {
-			// for both featured stories, add an 'acf_fc_layout' field with value of 'gmucf_featured_story' to the beginning of the array
-			$story['gmucf_left_featured_story']  = ['acf_fc_layout' => 'gmucf_featured_story'] + $story['gmucf_left_featured_story'];
-			$story['gmucf_right_featured_story'] = ['acf_fc_layout' => 'gmucf_featured_story'] + $story['gmucf_right_featured_story'];
+		} 
+		elseif ( $story['acf_fc_layout'] === 'gmucf_featured_stories_row' ) {
+			$story['gmucf_layout']      = $story['acf_fc_layout'];
+			$story['gmucf_featured_story_row'][] = gmucf_replace_story_default_values( $story['gmucf_left_featured_story'] );
+			$story['gmucf_featured_story_row'][] = gmucf_replace_story_default_values( $story['gmucf_right_featured_story'] );
+			
+			unset( $story['acf_fc_layout'] );
+			unset( $story['gmucf_left_featured_story'] );
+			unset( $story['gmucf_right_featured_story'] );
 
-			$retval[] = gmucf_replace_story_default_values( $story['gmucf_left_featured_story'] );
-			$retval[] = gmucf_replace_story_default_values( $story['gmucf_right_featured_story'] );
-		} elseif ( $story['acf_fc_layout'] === 'gmucf_spotlight' ) {
+			$retval[] = $story;
+		} 
+		elseif ( $story['acf_fc_layout'] === 'gmucf_spotlight' ) {
 			$story['gmucf_spotlight_image'] = $story['gmucf_spotlight_image']['sizes']['gmucf_top_story'];
 			$story['gmucf_layout']          = $story['acf_fc_layout'];
 

--- a/functions/gmucf-options.php
+++ b/functions/gmucf-options.php
@@ -31,6 +31,8 @@ function gmucf_replace_story_default_values( $story ) {
 	$post_id = $story['gmucf_story'];
 
 	$story['gmucf_story_permalink'] = get_permalink( $post_id );
+	$story['gmucf_layout']          = $story['acf_fc_layout'];
+	
 	if ( ! $story['gmucf_story_image'] ) {
 		$story['gmucf_story_image'] = get_the_post_thumbnail_url( $post_id, 'gmucf_top_story' );
 	} else {
@@ -44,6 +46,9 @@ function gmucf_replace_story_default_values( $story ) {
 	if ( ! $story['gmucf_story_description'] ) {
 		$story['gmucf_story_description'] = get_post_meta( $post_id, 'promo', true );
 	}
+
+	unset( $story['gmucf_story'] );
+	unset( $story['acf_fc_layout'] );
 
 	return $story;
 }

--- a/functions/gmucf-options.php
+++ b/functions/gmucf-options.php
@@ -68,7 +68,7 @@ function gmucf_stories_default_values( $stories ) {
 		if ( $story['acf_fc_layout'] === 'gmucf_top_story' ) {
 			$retval[] = gmucf_replace_story_default_values( $story );
 		} elseif ( $story['acf_fc_layout'] === 'gmucf_featured_stories_row' ) {
-			$story['gmucf_layout']      = $story['acf_fc_layout'];
+			$story['gmucf_layout']               = $story['acf_fc_layout'];
 			$story['gmucf_featured_story_row'][] = gmucf_replace_story_default_values( $story['gmucf_left_featured_story'] );
 			$story['gmucf_featured_story_row'][] = gmucf_replace_story_default_values( $story['gmucf_right_featured_story'] );
 

--- a/functions/gmucf-options.php
+++ b/functions/gmucf-options.php
@@ -30,6 +30,7 @@ if ( function_exists('acf_add_options_page') ) {
 function gmucf_replace_story_default_values( $story ) {
 	$post_id = $story['gmucf_story'];
 
+	$story['gmucf_story_permalink'] = get_permalink( $post_id );
 	if ( ! $story['gmucf_story_image'] ) {
 		$story['gmucf_story_image'] = get_the_post_thumbnail_url( $post_id, 'gmucf_top_story' );
 	} else {

--- a/functions/gmucf-options.php
+++ b/functions/gmucf-options.php
@@ -29,9 +29,6 @@ if ( function_exists('acf_add_options_page') ) {
  */
 function gmucf_replace_story_default_values( $story ) {
 	$post_id = $story['gmucf_story'];
-
-	$story['gmucf_story_permalink'] = get_permalink( $post_id );
-	$story['gmucf_layout']          = $story['acf_fc_layout'];
 	
 	if ( ! $story['gmucf_story_image'] ) {
 		$story['gmucf_story_image'] = get_the_post_thumbnail_url( $post_id, 'gmucf_top_story' );
@@ -46,9 +43,14 @@ function gmucf_replace_story_default_values( $story ) {
 	if ( ! $story['gmucf_story_description'] ) {
 		$story['gmucf_story_description'] = get_post_meta( $post_id, 'promo', true );
 	}
-	
+
+	$story['gmucf_story_permalink'] = get_permalink( $post_id );
+
+	if ( $story['acf_fc_layout'] ) {
+		$story['gmucf_layout'] = $story['acf_fc_layout'];
+		unset( $story['acf_fc_layout'] );
+	}
 	unset( $story['gmucf_story'] );
-	unset( $story['acf_fc_layout'] );
 
 	return $story;
 }

--- a/functions/gmucf-options.php
+++ b/functions/gmucf-options.php
@@ -29,17 +29,17 @@ if ( function_exists('acf_add_options_page') ) {
  */
 function gmucf_replace_story_default_values( $story ) {
 	$post_id = $story['gmucf_story'];
-	
+
 	if ( ! $story['gmucf_story_image'] ) {
 		$story['gmucf_story_image'] = get_the_post_thumbnail_url( $post_id, 'gmucf_top_story' );
 	} else {
 		$story['gmucf_story_image'] = $story['gmucf_story_image']['sizes']['gmucf_top_story'];
 	}
-	
+
 	if ( ! $story['gmucf_story_title'] ) {
 		$story['gmucf_story_title'] = get_the_title( $post_id );
 	}
-	
+
 	if ( ! $story['gmucf_story_description'] ) {
 		$story['gmucf_story_description'] = get_post_meta( $post_id, 'promo', true );
 	}
@@ -67,19 +67,17 @@ function gmucf_stories_default_values( $stories ) {
 	foreach ( $stories as $story ) {
 		if ( $story['acf_fc_layout'] === 'gmucf_top_story' ) {
 			$retval[] = gmucf_replace_story_default_values( $story );
-		} 
-		elseif ( $story['acf_fc_layout'] === 'gmucf_featured_stories_row' ) {
+		} elseif ( $story['acf_fc_layout'] === 'gmucf_featured_stories_row' ) {
 			$story['gmucf_layout']      = $story['acf_fc_layout'];
 			$story['gmucf_featured_story_row'][] = gmucf_replace_story_default_values( $story['gmucf_left_featured_story'] );
 			$story['gmucf_featured_story_row'][] = gmucf_replace_story_default_values( $story['gmucf_right_featured_story'] );
-			
+
 			unset( $story['acf_fc_layout'] );
 			unset( $story['gmucf_left_featured_story'] );
 			unset( $story['gmucf_right_featured_story'] );
 
 			$retval[] = $story;
-		} 
-		elseif ( $story['acf_fc_layout'] === 'gmucf_spotlight' ) {
+		} elseif ( $story['acf_fc_layout'] === 'gmucf_spotlight' ) {
 			$story['gmucf_spotlight_image'] = $story['gmucf_spotlight_image']['sizes']['gmucf_top_story'];
 			$story['gmucf_layout']          = $story['acf_fc_layout'];
 

--- a/functions/gmucf-options.php
+++ b/functions/gmucf-options.php
@@ -38,15 +38,15 @@ function gmucf_replace_story_default_values( $story ) {
 	} else {
 		$story['gmucf_story_image'] = $story['gmucf_story_image']['sizes']['gmucf_top_story'];
 	}
-
+	
 	if ( ! $story['gmucf_story_title'] ) {
 		$story['gmucf_story_title'] = get_the_title( $post_id );
 	}
-
+	
 	if ( ! $story['gmucf_story_description'] ) {
 		$story['gmucf_story_description'] = get_post_meta( $post_id, 'promo', true );
 	}
-
+	
 	unset( $story['gmucf_story'] );
 	unset( $story['acf_fc_layout'] );
 
@@ -74,6 +74,9 @@ function gmucf_stories_default_values( $stories ) {
 			$retval[] = gmucf_replace_story_default_values( $story['gmucf_right_featured_story'] );
 		} elseif ( $story['acf_fc_layout'] === 'gmucf_spotlight' ) {
 			$story['gmucf_spotlight_image'] = $story['gmucf_spotlight_image']['sizes']['gmucf_top_story'];
+			$story['gmucf_layout']          = $story['acf_fc_layout'];
+
+			unset( $story['acf_fc_layout'] );
 
 			$retval[] = $story;
 		} else {


### PR DESCRIPTION
**General Description:**
These changes clean up the feed a bit, by renaming the `acf_fc_layout` key to `gmucf_layout`, moves both of the featured stories from one row into an array together and adds the `gmucf_story_permalink` value to each story (which definitely needs to be there to use in the email 🤦‍♀️ ), and removes the `gmucf_story` value since the story ID is not needed in the feed.

**More Detailed:**
- Added gifs as an allowed file type for GMUCF story images
- Adds the story permalink (`gmucf_story_permalink`) to each story
- Adds `gmucf_layout` key and value (same as `acf_fc_layout`) to each story and removes the `acf_fc_layout` values. This is basically just renaming the `acf_fc_layout` key to a 'cleaner' name.
- Sets the `gmucf_layout` key value pair for the featured stories row
- Moves both the left and right featured stories inside of the `gmucf_featured_story_row` array so that they are grouped together and easier to loop through
- Removes the acf layout, left featured story and right featured story elements. That content is now all moved into the `gmucf_layout` and `gmucf_featured_story_row`